### PR TITLE
GitHub Issue テンプレート追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,21 @@
+name: バグ報告
+description: 不具合やエラーの報告
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: 何が起きたか
+      description: 期待した動作と実際の動作
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: バグを再現する手順（任意）
+  - type: textarea
+    id: environment
+    attributes:
+      label: 環境
+      description: OS、ブラウザなど（任意）

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,16 @@
+name: 機能リクエスト
+description: 新機能や改善の提案
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: やりたいこと
+      description: どんな機能がほしいか
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 背景・動機
+      description: なぜその機能が必要か（任意）


### PR DESCRIPTION
## Summary
- Feature Request / Bug Report の2つの Issue テンプレート（YAML フォーム形式）を追加
- Issue 作成時にフォーム選択が表示されるようになる

## Test plan
- [ ] GitHub の Issues → New Issue でテンプレート選択画面が表示されること
- [ ] 各テンプレートのフォームが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)