### PR TITLE
設定画面のfavicon追加 + 前年比の表示ロジック修正 (#37, #38)

### DIFF
--- a/src/analysis/compare.py
+++ b/src/analysis/compare.py
@@ -218,6 +218,27 @@ def compare_daily(db_path: str, target_date: str) -> ComparisonResult:
         conn.close()
 
 
+def _dynamic_label(target_date: str, compare_date: str | None, default_label: str) -> str:
+    """実際の比較日との差分に基づいてラベルを生成する。
+
+    データが不足して期待の期間に満たない場合は「n日前」「nヶ月前」を返す。
+    """
+    if compare_date is None:
+        return default_label
+    d = date.fromisoformat(target_date)
+    c = date.fromisoformat(compare_date)
+    days = (d - c).days
+    if default_label == "前月比" and days < 25:
+        return f"{days}日前"
+    if default_label == "前年比":
+        if days < 25:
+            return f"{days}日前"
+        months = (d.year - c.year) * 12 + d.month - c.month
+        if months < 11:
+            return f"{months}ヶ月前"
+    return default_label
+
+
 def compare_monthly(db_path: str, target_date: str) -> ComparisonResult:
     """前月比を計算する。"""
     conn = sqlite3.connect(db_path)
@@ -229,7 +250,8 @@ def compare_monthly(db_path: str, target_date: str) -> ComparisonResult:
         # 同日は除外
         if compare_date == target_date:
             compare_date = None
-        return _compute_diff(conn, target_date, compare_date, "前月比")
+        label = _dynamic_label(target_date, compare_date, "前月比")
+        return _compute_diff(conn, target_date, compare_date, label)
     finally:
         conn.close()
 
@@ -249,15 +271,22 @@ def compare_yearly(db_path: str, target_date: str) -> ComparisonResult:
         # 同日は除外
         if compare_date == target_date:
             compare_date = None
-        return _compute_diff(conn, target_date, compare_date, "前年比")
+        label = _dynamic_label(target_date, compare_date, "前年比")
+        return _compute_diff(conn, target_date, compare_date, label)
     finally:
         conn.close()
 
 
 def get_all_comparisons(db_path: str, target_date: str) -> list[ComparisonResult]:
-    """前日比・前月比・前年比をまとめて返す。"""
-    return [
-        compare_daily(db_path, target_date),
-        compare_monthly(db_path, target_date),
-        compare_yearly(db_path, target_date),
-    ]
+    """前日比・前月比・前年比をまとめて返す。
+
+    前月比と前年比の比較日が同じ場合、前年比は冗長なので除外する。
+    """
+    daily = compare_daily(db_path, target_date)
+    monthly = compare_monthly(db_path, target_date)
+    yearly = compare_yearly(db_path, target_date)
+    results = [daily, monthly]
+    # 前月比と前年比が同じ比較日なら前年比を省略
+    if yearly.compare_date is not None and yearly.compare_date != monthly.compare_date:
+        results.append(yearly)
+    return results

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -539,12 +539,16 @@ def _build_html(
                 lookup[key] = hd["diff"]
         diff_lookups.append(lookup)
 
+    # 比較期間のヘッダーラベル (前日比は常に表示、残りは comparisons に応じて動的)
+    comp_headers = "".join(f'<th class="num">{comp.label}</th>' for comp in comparisons)
+    hold_col_count = 3 + len(comparisons)  # 銘柄 + 評価額 + 損益 + 比較列
+
     hold_rows = ""
     current_class = None
     for h in holdings:
         if h["asset_class"] != current_class:
             current_class = h["asset_class"]
-            hold_rows += f'<tr class="group-header"><td colspan="6">{current_class}</td></tr>'
+            hold_rows += f'<tr class="group-header"><td colspan="{hold_col_count}">{current_class}</td></tr>'
         code = f'<span class="code">{h["code"]}</span> ' if h["code"] else ""
         qty = f' <span class="qty">x{h["quantity"]:,.0f}</span>' if h["quantity"] else ""
         # 評価損益セル
@@ -1021,7 +1025,7 @@ def _build_html(
       </div>
       <div class="card-body">
       <table class="hold-table">
-        <tr><th>銘柄</th><th class="num">評価額</th><th class="num">損益</th><th class="num">前日比</th><th class="num">前月比</th><th class="num">前年比</th></tr>
+        <tr><th>銘柄</th><th class="num">評価額</th><th class="num">損益</th>{comp_headers}</tr>
         {hold_rows}
       </table>
       </div>
@@ -2474,6 +2478,7 @@ def _build_settings_html(db_path: str, saved: str | None = None) -> str:
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='45' fill='%232881D7'/><path d='M50 5A45 45 0 0 1 95 50L50 50Z' fill='%23FCAD4C'/><path d='M50 5A45 45 0 0 0 10.2 72.5L50 50Z' fill='%230F7F30'/></svg>">
 <title>設定</title>
 <style>
   * {{ margin:0; padding:0; box-sizing:border-box; }}

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,7 +1,13 @@
 """repository.py のテスト — DB操作の正確性を検証。"""
 
+import json
+
 import pytest
 
+from src.analysis.compare import (
+    _dynamic_label,
+    get_all_comparisons,
+)
 from src.db.repository import (
     _adjusted_closing_date,
     _current_fiscal_month,
@@ -828,3 +834,100 @@ class TestClosingDay31:
         start, end = _fiscal_month_range("2025-03", 31)
         assert start == "2025-02-28"
         assert end == "2025-03-30"
+
+
+# ── 比較ラベル・フィルタリングのテスト ──────────────────────
+
+
+class TestDynamicLabel:
+    """_dynamic_label のテスト。"""
+
+    def test_monthly_enough_data(self):
+        """30日以上離れていれば「前月比」。"""
+        assert _dynamic_label("2025-03-01", "2025-01-30", "前月比") == "前月比"
+
+    def test_monthly_short_data(self):
+        """25日未満なら「n日前」。"""
+        assert _dynamic_label("2025-03-10", "2025-02-28", "前月比") == "10日前"
+
+    def test_yearly_enough_data(self):
+        """11ヶ月以上離れていれば「前年比」。"""
+        assert _dynamic_label("2025-12-01", "2024-12-01", "前年比") == "前年比"
+
+    def test_yearly_months(self):
+        """25日以上11ヶ月未満なら「nヶ月前」。"""
+        assert _dynamic_label("2025-06-01", "2025-03-01", "前年比") == "3ヶ月前"
+
+    def test_yearly_short_data(self):
+        """25日未満なら「n日前」。"""
+        assert _dynamic_label("2025-03-10", "2025-02-28", "前年比") == "10日前"
+
+    def test_none_compare_date(self):
+        """compare_date が None ならデフォルトラベル。"""
+        assert _dynamic_label("2025-03-01", None, "前月比") == "前月比"
+
+
+class TestGetAllComparisons:
+    """get_all_comparisons のフィルタリングテスト。"""
+
+    @pytest.fixture
+    def short_db(self, tmp_path):
+        """5日分のデータしかない DB。"""
+        db_path = str(tmp_path / "short.db")
+        init_db(db_path)
+        import sqlite3
+
+        conn = sqlite3.connect(db_path)
+        for i in range(5):
+            d = f"2025-03-{10 + i:02d}"
+            conn.execute(
+                "INSERT INTO snapshots (date, total_asset, by_class_json, raw_path) VALUES (?, ?, ?, ?)",
+                (d, 1_000_000 + i * 10_000, json.dumps({"預金": 1_000_000 + i * 10_000}), ""),
+            )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    @pytest.fixture
+    def long_db(self, tmp_path):
+        """1年以上のデータがある DB。"""
+        db_path = str(tmp_path / "long.db")
+        init_db(db_path)
+        import sqlite3
+
+        conn = sqlite3.connect(db_path)
+        for d, v in [
+            ("2024-01-15", 800_000),
+            ("2024-12-15", 950_000),
+            ("2025-01-14", 980_000),
+            ("2025-01-15", 1_000_000),
+        ]:
+            conn.execute(
+                "INSERT INTO snapshots (date, total_asset, by_class_json, raw_path) VALUES (?, ?, ?, ?)",
+                (d, v, json.dumps({"預金": v}), ""),
+            )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def test_short_data_drops_yearly(self, short_db):
+        """データが5日分しかない場合、前年比は除外される。"""
+        results = get_all_comparisons(short_db, "2025-03-14")
+        labels = [r.label for r in results]
+        assert len(results) == 2
+        assert labels[0] == "前日比"
+        assert "日前" in labels[1]
+
+    def test_short_data_monthly_label(self, short_db):
+        """データ不足時、前月比は「n日前」ラベルになる。"""
+        results = get_all_comparisons(short_db, "2025-03-14")
+        monthly = results[1]
+        assert monthly.label == "4日前"
+        assert monthly.compare_date == "2025-03-10"
+
+    def test_long_data_has_three(self, long_db):
+        """1年分のデータがあれば3つの比較が返る。"""
+        results = get_all_comparisons(long_db, "2025-01-15")
+        assert len(results) == 3
+        assert results[1].label == "前月比"
+        assert results[2].label == "前年比"

--- a/tests/test_server_html.py
+++ b/tests/test_server_html.py
@@ -492,3 +492,40 @@ class TestClosingDaySetting:
         assert "設定日前の平日" in html
         assert "設定日後の平日" in html
         assert 'name="holiday_mode"' in html
+
+
+# --- Favicon (#37) ---
+
+
+class TestFavicon:
+    """全ページに favicon が設定されている。"""
+
+    def test_dashboard_has_favicon(self):
+        html = _build_html(_demo_data(), [_demo_data()["date"]])
+        assert 'rel="icon"' in html
+
+    def test_cf_has_favicon(self):
+        html = _build_cf_html(_demo_cf_data())
+        assert 'rel="icon"' in html
+
+    def test_plan_has_favicon(self):
+        html = _build_plan_html(_demo_plan_data())
+        assert 'rel="icon"' in html
+
+    def test_settings_has_favicon(self):
+        html = _build_settings_html("dummy_db", saved=False)
+        assert 'rel="icon"' in html
+
+
+# --- 比較ラベルの動的表示 (#38) ---
+
+
+class TestComparisonHeaders:
+    """保有銘柄テーブルのヘッダーが比較結果に応じて動的に変わる。"""
+
+    def test_demo_has_three_comparison_headers(self):
+        """デモデータ（十分なデータ量）では前日比・前月比・前年比の3列。"""
+        html = _build_html(_demo_data(), [_demo_data()["date"]])
+        assert "前日比" in html
+        assert "前月比" in html
+        assert "前年比" in html


### PR DESCRIPTION
## Summary
- **#37**: 設定画面に他ページと同じ favicon を追加
- **#38**: データ不足時に前月比/前年比のラベルを「n日前」「nヶ月前」に動的変更。前月比と前年比が同じ比較日の場合は前年比を非表示に

## Test plan
- [x] 全162テスト通過
- [x] 全4ページに favicon が存在することをテストで検証
- [x] `_dynamic_label` のラベル生成ロジックをテストで検証
- [x] データ不足時に前年比が除外されることをテストで検証
- [ ] デモモードで保有銘柄テーブルの表示を目視確認
- [ ] 設定画面のブラウザタブに favicon が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)