### PR TITLE
.gitignore にテスト一時DBファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ raw/
 # SQLite database
 data/*.db
 *.db
+*-shm
+*-wal
+dummy_db
+test_db
 
 # Cache data (contains portfolio-derived info)
 data/dividends.json


### PR DESCRIPTION
## Summary
- `dummy_db`, `test_db`, `*-shm`, `*-wal` を .gitignore に追加
- テスト実行時に生成される一時ファイルが untracked 表示されなくなる

🤖 Generated with [Claude Code](https://claude.com/claude-code)