### PR TITLE
投資信託の評価額・取得価額推移グラフ (#34)

### DIFF
--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from datetime import date as date_cls
+from datetime import timedelta
 
 from src.parser.cashflow import CashflowMonth
 from src.parser.cf_csv import CfTransaction
@@ -849,3 +851,41 @@ def get_cf_dividend_history(conn: sqlite3.Connection, closing_day: int = 1, holi
     annual = [{"year": y, "amount": a} for y, a in sorted(yearly.items())]
 
     return {"monthly": monthly, "annual": annual}
+
+
+# --- 投資信託 評価額・取得価額推移 ---
+
+
+def get_fund_total_history(conn: sqlite3.Connection, months: int = 13) -> list[dict]:
+    """投資信託の評価額合計・取得価額合計の時系列データを返す。
+
+    取得価額 = value - unrealized_gain で算出。
+    ある日付で一部銘柄でも unrealized_gain が NULL なら、その日の total_cost は NULL とする。
+
+    Args:
+        months: 取得期間（月数、1ヶ月=30日換算）。デフォルト13ヶ月（JS側の1年表示+余裕）。
+
+    Returns: [{"date": "2026-02-15", "total_value": 6280000, "total_cost": 5500000}, ...]
+    """
+    # DB 内の最新日を基準にカットオフを計算
+    latest_row = conn.execute("SELECT MAX(date) FROM snapshot_holdings WHERE asset_class = '投資信託'").fetchone()
+    if not latest_row or not latest_row[0]:
+        return []
+
+    latest_dt = date_cls.fromisoformat(latest_row[0])
+    cutoff = (latest_dt - timedelta(days=months * 30)).isoformat()
+
+    rows = conn.execute(
+        """SELECT date,
+                  SUM(value),
+                  CASE WHEN COUNT(*) = COUNT(unrealized_gain)
+                       THEN SUM(value - unrealized_gain)
+                  END
+           FROM snapshot_holdings
+           WHERE asset_class = '投資信託' AND date >= ?
+           GROUP BY date
+           ORDER BY date ASC""",
+        (cutoff,),
+    ).fetchall()
+
+    return [{"date": r[0], "total_value": r[1], "total_cost": r[2]} for r in rows if r[1] is not None]

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -36,6 +36,7 @@ from src.db.repository import (
     get_cf_income_trend,
     get_cf_monthly_trend,
     get_daily_assets,
+    get_fund_total_history,
     get_setting,
     save_budgets,
     save_cf_csv_month,
@@ -323,6 +324,8 @@ def _get_data(db_path: str, date: str | None = None) -> dict:
                 (date,),
             ).fetchall()
         ]
+
+        fund_total_history = get_fund_total_history(conn)
     finally:
         conn.close()
 
@@ -430,6 +433,7 @@ def _get_data(db_path: str, date: str | None = None) -> dict:
         "max_drawdown": mdd,
         "concentration": conc,
         "comparisons": comparisons,
+        "fund_total_history": fund_total_history,
     }
 
 
@@ -448,6 +452,52 @@ def _avg_yield_html(dividends: list[dict]) -> str:
         avg_yield = total_div / total_value * 100
         return f"　加重平均利回り {avg_yield:.2f}%"
     return ""
+
+
+def _fund_total_card_html(fund_total_history: list[dict]) -> str:
+    """投資信託 評価額・取得価額推移カードの HTML を返す。"""
+    if not fund_total_history:
+        return ""
+
+    latest = fund_total_history[-1]
+    total_value = latest["total_value"]
+    total_cost = latest.get("total_cost")
+
+    # サマリー行
+    value_str = f"¥{total_value:,.0f}"
+    summary_html = f'<span style="font-size:1.5em;font-weight:bold">{value_str}</span>'
+
+    if total_cost is not None and total_cost > 0:
+        gain = total_value - total_cost
+        gain_pct = gain / total_cost * 100
+        gain_color = "#e17055" if gain >= 0 else "#0984e3"
+        sign = "+" if gain >= 0 else ""
+        summary_html += f"""
+        <div style="margin-top:8px;display:flex;gap:24px;flex-wrap:wrap">
+          <div><span style="color:#888">取得価額</span> ¥{total_cost:,.0f}</div>
+          <div><span style="color:#888">評価損益</span>
+            <span style="color:{gain_color};font-weight:bold">{sign}¥{gain:,.0f} ({gain_pct:.2f}%)</span>
+          </div>
+        </div>"""
+
+    # 期間切り替えボタン
+    range_btns = """<div style="text-align:right;margin-bottom:8px">
+      <button class="ft-range-btn active" data-days="90" style="padding:2px 10px;margin:0 2px;border:1px solid #ddd;border-radius:4px;background:#fff;cursor:pointer">3ヶ月</button>
+      <button class="ft-range-btn" data-days="180" style="padding:2px 10px;margin:0 2px;border:1px solid #ddd;border-radius:4px;background:#fff;cursor:pointer">6ヶ月</button>
+      <button class="ft-range-btn" data-days="365" style="padding:2px 10px;margin:0 2px;border:1px solid #ddd;border-radius:4px;background:#fff;cursor:pointer">1年</button>
+    </div>"""
+
+    return f"""<div class="card full" data-card-id="dash-fund-total">
+      <div class="card-header">
+        <h2>投資信託 評価額・取得価額推移</h2>
+        <button class="collapse-btn">&#x25BC;</button>
+      </div>
+      <div class="card-body">
+        <div style="margin-bottom:12px">{summary_html}</div>
+        {range_btns}
+        <canvas id="fund-total-chart" height="260"></canvas>
+      </div>
+    </div>"""
 
 
 def _build_html(
@@ -475,6 +525,7 @@ def _build_html(
     mdd = data.get("max_drawdown")
     conc = data.get("concentration")
     comparisons = data.get("comparisons", [])
+    fund_total_history = data.get("fund_total_history", [])
 
     # 日付セレクタ
     date_options = ""
@@ -1022,6 +1073,8 @@ def _build_html(
       </div>
     </div>
 
+    {_fund_total_card_html(fund_total_history)}
+
     <div class="card full" data-card-id="dash-holdings">
       <div class="card-header">
         <h2>保有銘柄 ({len(holdings)})</h2>
@@ -1083,6 +1136,149 @@ const pollId = setInterval(async () => {{
         if not skip_update
         else ""
     }
+
+// --- 投資信託 評価額・取得価額推移グラフ ---
+(function() {{
+  const ftData = {json.dumps(fund_total_history, ensure_ascii=False)};
+  const ftCanvas = document.getElementById('fund-total-chart');
+  if (!ftData.length || !ftCanvas) return;
+
+  let ftRange = 90;  // デフォルト3ヶ月
+  const ftBtns = document.querySelectorAll('.ft-range-btn');
+  ftBtns.forEach(btn => btn.addEventListener('click', function() {{
+    ftBtns.forEach(b => b.classList.remove('active'));
+    this.classList.add('active');
+    ftRange = parseInt(this.dataset.days);
+    drawFundTotalChart();
+  }}));
+
+  function drawFundTotalChart() {{
+    // 期間フィルタ
+    const now = new Date(ftData[ftData.length - 1].date);
+    const cutoff = new Date(now);
+    cutoff.setDate(cutoff.getDate() - ftRange);
+    const filtered = ftData.filter(d => new Date(d.date) >= cutoff);
+    if (!filtered.length) return;
+
+    const ctx = ftCanvas.getContext('2d');
+    const W = ftCanvas.parentElement.clientWidth - 40;
+    ftCanvas.width = W;
+    ftCanvas.height = 260;
+    ctx.clearRect(0, 0, W, 260);
+
+    const pad = {{ left: 80, right: 20, top: 20, bottom: 30 }};
+    const cW = W - pad.left - pad.right;
+    const cH = 260 - pad.top - pad.bottom;
+
+    // Y軸レンジ
+    let allVals = [];
+    filtered.forEach(d => {{
+      allVals.push(d.total_value || 0);
+      if (d.total_cost != null) allVals.push(d.total_cost);
+    }});
+    const minVal = Math.min(...allVals) * 0.95;
+    const maxVal = Math.max(...allVals) * 1.05;
+    const range = maxVal - minVal || 1;
+
+    const toY = v => pad.top + cH * (1 - (v - minVal) / range);
+    const toX = i => pad.left + (cW / (filtered.length - 1 || 1)) * i;
+
+    // Y軸グリッド
+    ctx.strokeStyle = '#f1f2f6';
+    ctx.fillStyle = '#b2bec3';
+    ctx.font = '11px sans-serif';
+    ctx.textAlign = 'right';
+    for (let i = 0; i <= 4; i++) {{
+      const y = pad.top + cH * (1 - i / 4);
+      const val = minVal + range * i / 4;
+      ctx.beginPath(); ctx.moveTo(pad.left, y); ctx.lineTo(W - pad.right, y); ctx.stroke();
+      ctx.fillText((val / 10000).toFixed(0) + '\u4e07', pad.left - 6, y + 4);
+    }}
+
+    // 取得価額ライン（グレー）
+    const hasCost = filtered.some(d => d.total_cost != null);
+    if (hasCost) {{
+      ctx.strokeStyle = '#b2bec3';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      let started = false;
+      filtered.forEach((d, i) => {{
+        if (d.total_cost == null) return;
+        const x = toX(i), y = toY(d.total_cost);
+        if (!started) {{ ctx.moveTo(x, y); started = true; }} else ctx.lineTo(x, y);
+      }});
+      ctx.stroke();
+    }}
+
+    // 評価額ライン（オレンジ）
+    ctx.strokeStyle = '#E67E22';
+    ctx.lineWidth = 2.5;
+    ctx.beginPath();
+    filtered.forEach((d, i) => {{
+      const x = toX(i), y = toY(d.total_value);
+      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }});
+    ctx.stroke();
+
+    // X軸ラベル
+    const step = Math.max(1, Math.floor(filtered.length / 8));
+    ctx.fillStyle = '#636e72';
+    ctx.font = '11px sans-serif';
+    ctx.textAlign = 'center';
+    filtered.forEach((d, i) => {{
+      if (i % step === 0 || i === filtered.length - 1) {{
+        ctx.fillText(d.date.substring(5), toX(i), pad.top + cH + 18);
+      }}
+    }});
+
+    // 凡例
+    let lx = pad.left;
+    ctx.font = '11px sans-serif';
+    ctx.textAlign = 'left';
+    [['#E67E22', '\u8a55\u4fa1\u984d'], ['#b2bec3', '\u53d6\u5f97\u4fa1\u984d']].forEach(([color, label]) => {{
+      ctx.fillStyle = color;
+      ctx.fillRect(lx, 6, 14, 10);
+      ctx.fillStyle = '#2d3436';
+      ctx.fillText(label, lx + 17, 14);
+      lx += ctx.measureText(label).width + 32;
+    }});
+
+    // ツールチップ
+    ftCanvas.onmousemove = function(e) {{
+      const rect = ftCanvas.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const idx = Math.round((mx - pad.left) / (cW / (filtered.length - 1 || 1)));
+      if (idx < 0 || idx >= filtered.length) {{ const tip = document.getElementById('pie-tooltip'); if (tip) tip.classList.remove('show'); return; }}
+      const d = filtered[idx];
+      let html = '<strong>' + esc(d.date) + '</strong>';
+      html += '<div style="margin-top:4px;border-top:1px solid rgba(255,255,255,0.2);padding-top:4px">';
+      html += '<div style="display:flex;justify-content:space-between;gap:12px"><span style="color:#E67E22">\u25cf \u8a55\u4fa1\u984d</span><span>' + (d.total_value/10000).toLocaleString('ja-JP',{{maximumFractionDigits:0}}) + '\u4e07</span></div>';
+      if (d.total_cost != null && d.total_cost > 0) {{
+        html += '<div style="display:flex;justify-content:space-between;gap:12px"><span style="color:#b2bec3">\u25cf \u53d6\u5f97\u4fa1\u984d</span><span>' + (d.total_cost/10000).toLocaleString('ja-JP',{{maximumFractionDigits:0}}) + '\u4e07</span></div>';
+        const gain = d.total_value - d.total_cost;
+        const pct = (gain / d.total_cost * 100).toFixed(2);
+        const clr = gain >= 0 ? '#e17055' : '#0984e3';
+        html += '<div style="display:flex;justify-content:space-between;gap:12px"><span>\u640d\u76ca</span><span style="color:' + clr + '">' + (gain >= 0 ? '+' : '') + (gain/10000).toLocaleString('ja-JP',{{maximumFractionDigits:0}}) + '\u4e07 (' + pct + '%)</span></div>';
+      }}
+      html += '</div>';
+      const tip = document.getElementById('pie-tooltip');
+      if (tip) {{
+        tip.innerHTML = html;
+        tip.classList.add('show');
+        tip.style.left = Math.min(e.clientX + 14, window.innerWidth - 260) + 'px';
+        tip.style.top = (e.clientY - 10) + 'px';
+      }}
+    }};
+    ftCanvas.onmouseleave = function() {{
+      const tip = document.getElementById('pie-tooltip');
+      if (tip) tip.classList.remove('show');
+    }};
+  }}
+
+  drawFundTotalChart();
+  window.addEventListener('resize', drawFundTotalChart);
+}})();
+
 {_COLLAPSE_JS}
 </script>
 </body>
@@ -1540,6 +1736,29 @@ def _demo_data() -> dict:
     for v in demo_sector_holdings.values():
         v.sort(key=lambda x: x["value"], reverse=True)
 
+    # 投資信託 評価額・取得価額推移デモデータ（365日分）
+    import random
+
+    rng = random.Random(42)
+    fund_base_cost = 3_600_000  # 取得価額の開始値
+    fund_total_history = []
+    cost = fund_base_cost
+    for i in range(365):
+        d = date.today() - timedelta(days=364 - i)
+        # 取得価額: 毎月1日に積立で階段状に増加
+        if d.day == 1:
+            cost += 50_000
+        # 評価額: 取得価額 + 含み益（市場変動あり）
+        growth_rate = 1 + 0.0002 * i + rng.uniform(-0.008, 0.008)
+        value = cost * growth_rate * (1 + 0.1)  # 約10%の含み益ベース
+        fund_total_history.append(
+            {
+                "date": d.isoformat(),
+                "total_value": round(value),
+                "total_cost": round(cost),
+            }
+        )
+
     return {
         "date": today,
         "total_asset": total_asset,
@@ -1556,6 +1775,7 @@ def _demo_data() -> dict:
         "concentration": {"top_n": [], "concentration_pct": 32.5},
         "comparisons": demo_comparisons,
         "_sector_holdings": demo_sector_holdings,
+        "fund_total_history": fund_total_history,
     }
 
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -931,3 +931,137 @@ class TestGetAllComparisons:
         assert len(results) == 3
         assert results[1].label == "前月比"
         assert results[2].label == "前年比"
+
+
+# --- 投資信託 評価額・取得価額推移 ---
+
+
+class TestGetFundTotalHistory:
+    """get_fund_total_history のテスト。"""
+
+    @pytest.fixture
+    def fund_db(self, tmp_path):
+        """投資信託テストデータを持つDB。"""
+        db_path = tmp_path / "fund_test.db"
+        c = init_db(str(db_path))
+
+        # スナップショット3日分
+        for d in ["2025-10-13", "2025-10-14", "2025-10-15"]:
+            c.execute("INSERT OR IGNORE INTO snapshots VALUES (?, 10000000, '{}', '')", (d,))
+
+        # 投資信託の保有データ（value, unrealized_gain あり）
+        holdings = [
+            # date, code, name, qty, value, class, pos, acq_price, cur_price, unrealized_gain, unrealized_gain_pct
+            ("2025-10-13", "", "ファンドA", 100000, 2_000_000, "投資信託", 0, 15000, 20000, 200_000, 11.11),
+            ("2025-10-13", "", "ファンドB", 80000, 1_500_000, "投資信託", 1, 14000, 18750, 150_000, 11.11),
+            ("2025-10-14", "", "ファンドA", 100000, 2_050_000, "投資信託", 0, 15000, 20500, 250_000, 13.89),
+            ("2025-10-14", "", "ファンドB", 80000, 1_520_000, "投資信託", 1, 14000, 19000, 170_000, 12.59),
+            ("2025-10-15", "", "ファンドA", 100000, 2_100_000, "投資信託", 0, 15000, 21000, 300_000, 16.67),
+            ("2025-10-15", "", "ファンドB", 80000, 1_550_000, "投資信託", 1, 14000, 19375, 200_000, 14.81),
+            # 株式（投資信託以外は含まれないことを確認）
+            ("2025-10-15", "7203", "トヨタ自動車", 100, 1_000_000, "株式（現物）", 0, 8000, 10000, 200_000, 25.0),
+        ]
+        c.executemany(
+            """INSERT INTO snapshot_holdings
+               (date, symbol_or_code, name, quantity, value, asset_class, position,
+                acquisition_price, current_price, unrealized_gain, unrealized_gain_pct)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            holdings,
+        )
+        c.commit()
+        return str(db_path)
+
+    def test_basic_history(self, fund_db):
+        """投資信託の評価額・取得価額合計が日付順に返る。"""
+        from src.db.repository import get_fund_total_history
+
+        conn = init_db(fund_db)
+        result = get_fund_total_history(conn, months=6)
+        conn.close()
+
+        assert len(result) == 3
+        # 日付が昇順
+        assert result[0]["date"] == "2025-10-13"
+        assert result[2]["date"] == "2025-10-15"
+
+        # 2025-10-13: value=2M+1.5M=3.5M, cost=(2M-200K)+(1.5M-150K)=3.15M
+        assert result[0]["total_value"] == 3_500_000
+        assert result[0]["total_cost"] == 3_150_000
+
+        # 2025-10-15: value=2.1M+1.55M=3.65M, cost=(2.1M-300K)+(1.55M-200K)=3.15M
+        assert result[2]["total_value"] == 3_650_000
+        assert result[2]["total_cost"] == 3_150_000
+
+    def test_empty_db(self, tmp_path):
+        """投資信託データがない場合は空リスト。"""
+        from src.db.repository import get_fund_total_history
+
+        db_path = tmp_path / "empty.db"
+        conn = init_db(str(db_path))
+        result = get_fund_total_history(conn, months=6)
+        conn.close()
+        assert result == []
+
+    def test_null_unrealized_gain(self, tmp_path):
+        """unrealized_gain が NULL の場合、total_cost は NULL になる。"""
+        from src.db.repository import get_fund_total_history
+
+        db_path = tmp_path / "null_gain.db"
+        conn = init_db(str(db_path))
+        conn.execute("INSERT INTO snapshots VALUES ('2025-10-15', 5000000, '{}', '')")
+        conn.execute(
+            """INSERT INTO snapshot_holdings
+               (date, symbol_or_code, name, quantity, value, asset_class, position,
+                acquisition_price, current_price, unrealized_gain, unrealized_gain_pct)
+               VALUES ('2025-10-15', '', 'ファンドA', 100000, 2000000, '投資信託', 0, NULL, NULL, NULL, NULL)"""
+        )
+        conn.commit()
+
+        result = get_fund_total_history(conn, months=6)
+        conn.close()
+
+        assert len(result) == 1
+        assert result[0]["total_value"] == 2_000_000
+        assert result[0]["total_cost"] is None
+
+    def test_partial_null_unrealized_gain(self, tmp_path):
+        """一部銘柄だけ unrealized_gain が NULL なら、その日の total_cost は NULL。"""
+        from src.db.repository import get_fund_total_history
+
+        db_path = tmp_path / "partial_null.db"
+        conn = init_db(str(db_path))
+        conn.execute("INSERT INTO snapshots VALUES ('2025-10-15', 5000000, '{}', '')")
+        # ファンドA: unrealized_gain あり
+        conn.execute(
+            """INSERT INTO snapshot_holdings
+               (date, symbol_or_code, name, quantity, value, asset_class, position,
+                acquisition_price, current_price, unrealized_gain, unrealized_gain_pct)
+               VALUES ('2025-10-15', '', 'ファンドA', 100000, 2000000, '投資信託', 0, 15000, 20000, 200000, 11.11)"""
+        )
+        # ファンドB: unrealized_gain が NULL
+        conn.execute(
+            """INSERT INTO snapshot_holdings
+               (date, symbol_or_code, name, quantity, value, asset_class, position,
+                acquisition_price, current_price, unrealized_gain, unrealized_gain_pct)
+               VALUES ('2025-10-15', '', 'ファンドB', 80000, 1500000, '投資信託', 1, NULL, NULL, NULL, NULL)"""
+        )
+        conn.commit()
+
+        result = get_fund_total_history(conn, months=6)
+        conn.close()
+
+        assert len(result) == 1
+        assert result[0]["total_value"] == 3_500_000  # 両方の value 合計
+        assert result[0]["total_cost"] is None  # 一部 NULL → 全体 NULL
+
+    def test_excludes_stocks(self, fund_db):
+        """株式（現物）は集計に含まれない。"""
+        from src.db.repository import get_fund_total_history
+
+        conn = init_db(fund_db)
+        result = get_fund_total_history(conn, months=6)
+        conn.close()
+
+        # 2025-10-15 の total_value に株式の100万は含まれない
+        day15 = [r for r in result if r["date"] == "2025-10-15"][0]
+        assert day15["total_value"] == 3_650_000  # ファンドA+B のみ

--- a/tests/test_server_html.py
+++ b/tests/test_server_html.py
@@ -723,3 +723,50 @@ class TestSimulator:
         result = self.data["result"]
         assert len(result.yearly_balances) > 0
         assert result.total_principal > 0
+
+
+class TestFundTotalCard:
+    """投資信託 評価額・取得価額推移カードのテスト。"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        data = _demo_data()
+        self.html = _build_html(data, [data["date"]], skip_update=True, demo=True)
+
+    def test_card_exists(self):
+        """投資信託カードが存在する。"""
+        assert 'data-card-id="dash-fund-total"' in self.html
+
+    def test_card_title(self):
+        """カードタイトルが表示されている。"""
+        assert "投資信託 評価額・取得価額推移" in self.html
+
+    def test_canvas_exists(self):
+        """グラフ用 canvas が存在する。"""
+        assert 'id="fund-total-chart"' in self.html
+
+    def test_range_buttons(self):
+        """期間切り替えボタンが存在する。"""
+        assert "3ヶ月" in self.html
+        assert "6ヶ月" in self.html
+        assert "1年" in self.html
+
+    def test_summary_values(self):
+        """評価額と取得価額のサマリーが表示されている。"""
+        assert "取得価額" in self.html
+        assert "評価損益" in self.html
+
+    def test_demo_data_has_fund_history(self):
+        """デモデータに fund_total_history が含まれる。"""
+        data = _demo_data()
+        fth = data.get("fund_total_history", [])
+        assert len(fth) == 365
+        assert "total_value" in fth[0]
+        assert "total_cost" in fth[0]
+
+    def test_no_card_when_empty(self):
+        """fund_total_history が空ならカードは表示されない。"""
+        data = _demo_data()
+        data["fund_total_history"] = []
+        html = _build_html(data, [data["date"]], skip_update=True, demo=True)
+        assert 'data-card-id="dash-fund-total"' not in html


### PR DESCRIPTION
## Summary
- 投資信託の**評価額**（オレンジ）と**取得価額**（グレー）の2本線推移グラフをダッシュボードに追加
- `get_fund_total_history()` で `snapshot_holdings` から日次の合計値を算出（`取得価額 = value - unrealized_gain`）
- 3ヶ月/6ヶ月/1年の期間切り替え、ホバーツールチップ、サマリー（評価額・取得価額・損益）表示

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| `src/db/repository.py` | `get_fund_total_history()` 追加 |
| `src/web/server.py` | `_fund_total_card_html()` + Canvas グラフ JS + デモデータ |
| `tests/test_repository.py` | 5テスト（基本、空DB、全NULL、partial NULL、株式除外） |
| `tests/test_server_html.py` | 7テスト（カード存在、タイトル、canvas、ボタン、サマリー等） |

## Test plan
- [x] pytest 222件 全パス
- [x] ruff check + format クリーン
- [x] Claude / Codex / Gemini の3者レビュー済み
- [ ] デモモード (`--demo`) でグラフ表示・期間切り替え・ツールチップ確認
- [ ] 実データでグラフ表示確認
- [ ] モバイル表示の崩れがないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)