### PR TITLE
過去月DL管理の月ピッカーを年・月セレクトに置換 (#49)

### DIFF
--- a/src/web/server.py
+++ b/src/web/server.py
@@ -4320,6 +4320,15 @@ def _build_cf_html(data: dict, skip_update: bool = False, ai_comment: str | None
         )
         dl_rows += f"<tr><td>{safe_ym}</td><td>{status}</td><td>{dl_btn}</td></tr>"
 
+    # 年・月セレクトボックスの選択肢を生成
+    now = datetime.now()
+    year_options = "".join(
+        f'<option value="{y}"{" selected" if y == now.year else ""}>{y}</option>' for y in range(now.year, 2019, -1)
+    )
+    month_options = "".join(
+        f'<option value="{m:02d}"{" selected" if m == now.month else ""}>{m}月</option>' for m in range(1, 13)
+    )
+
     balance_sign = "+" if balance >= 0 else ""
     balance_css = "plus" if balance >= 0 else "minus"
 
@@ -4660,7 +4669,12 @@ def _build_cf_html(data: dict, skip_update: bool = False, ai_comment: str | None
       </div>
       <div class="card-body">
         <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">
-          <input type="month" id="manual-month" style="padding:4px 8px;border:1px solid #dfe6e9;border-radius:6px;font-size:0.9rem">
+          <select id="manual-year" style="padding:4px 8px;border:1px solid #dfe6e9;border-radius:6px;font-size:0.9rem">{
+        year_options
+    }</select>
+          <select id="manual-month-sel" style="padding:4px 8px;border:1px solid #dfe6e9;border-radius:6px;font-size:0.9rem">{
+        month_options
+    }</select>
           <button class="dl-btn" onclick="fetchManualMonth()">取得</button>
           <span id="manual-msg" style="font-size:0.8rem;color:#636e72"></span>
         </div>
@@ -4864,10 +4878,11 @@ async function downloadMonth(ym, btn) {{
 }}
 
 async function fetchManualMonth() {{
-  const input = document.getElementById('manual-month');
+  const year = document.getElementById('manual-year').value;
+  const month = document.getElementById('manual-month-sel').value;
   const msg = document.getElementById('manual-msg');
-  const ym = input.value;
-  if (!ym) {{ msg.textContent = '年月を選択してください'; return; }}
+  const ym = year + '-' + month;
+  if (!year || !month) {{ msg.textContent = '年月を選択してください'; return; }}
   // YYYY-MM format validation
   const today = new Date();
   const sel = new Date(ym + '-01');

--- a/tests/test_server_html.py
+++ b/tests/test_server_html.py
@@ -210,10 +210,14 @@ class TestCfCards:
 class TestManualMonthFetch:
     """任意の過去月を指定してCSV取得するUIが存在する。"""
 
-    def test_month_input_exists(self):
+    def test_year_month_select_exists(self):
         html = _build_cf_html(_demo_cf_data())
-        assert 'type="month"' in html
-        assert 'id="manual-month"' in html
+        assert 'id="manual-year"' in html
+        assert 'id="manual-month-sel"' in html
+        # 現在年が選択肢に含まれる
+        from datetime import datetime
+
+        assert f'value="{datetime.now().year}"' in html
 
     def test_fetch_button_exists(self):
         html = _build_cf_html(_demo_cf_data())


### PR DESCRIPTION
## Summary
- `<input type="month">` のネイティブピッカーではブラウザによって年ナビゲーションが制限され、昨年以前を選択しづらいバグを修正
- 年（2020〜現在年）と月（1〜12月）を別々の `<select>` に置き換え、確実に任意の年月を選択可能に

Closes #49

## Test plan
- [x] pytest 全222テスト通過
- [ ] `--demo` モードで CF ページを開き、年・月セレクトが正しく表示されることを確認
- [ ] 2020年〜現在年の範囲で年を選択できることを確認
- [ ] 月を選択して「取得」ボタンが動作することを確認
- [ ] 未来の月を選択した場合にバリデーションエラーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)