### PR TITLE
家計簿AI診断に経過日数・経過率を追加 (#61)

### DIFF
--- a/src/analysis/ai_comment.py
+++ b/src/analysis/ai_comment.py
@@ -10,9 +10,11 @@ import json
 import logging
 import os
 import sqlite3
-from datetime import datetime
+from datetime import date, datetime
 
 from src.db.repository import (
+    _current_fiscal_month,
+    _fiscal_month_range,
     get_budgets,
     get_cashflows,
     get_cf_available_months,
@@ -240,8 +242,6 @@ def _build_lifeplan_prompt(db_path: str, date: str) -> str:
 
 def _build_cf_prompt(db_path: str, year_month: str) -> str:
     """家計簿分析用のプロンプトを組み立てる。"""
-    import calendar
-
     conn = init_db(db_path)
     try:
         closing_day = int(get_setting(conn, "closing_day", "1") or "1")
@@ -256,21 +256,23 @@ def _build_cf_prompt(db_path: str, year_month: str) -> str:
     if not summary:
         return ""
 
-    # 経過日数の計算
-    today = datetime.now()
-    ym_year, ym_month = int(year_month[:4]), int(year_month[5:7])
-    days_in_month = calendar.monthrange(ym_year, ym_month)[1]
-    today_ym = today.strftime("%Y-%m")
-    if year_month == today_ym:
-        elapsed_days = today.day
-        is_partial = elapsed_days < days_in_month
-    elif year_month < today_ym:
-        elapsed_days = days_in_month
+    # fiscal month の期間と経過日数を計算
+    today = date.today()
+    current_fm = _current_fiscal_month(closing_day, holiday_mode)
+    start_str, end_str = _fiscal_month_range(year_month, closing_day, holiday_mode)
+    start_date = date.fromisoformat(start_str)
+    end_date = date.fromisoformat(end_str)
+    total_days = (end_date - start_date).days + 1
+    if year_month == current_fm:
+        elapsed_days = (today - start_date).days + 1
+        is_partial = today <= end_date
+    elif year_month < current_fm:
+        elapsed_days = total_days
         is_partial = False
     else:
         elapsed_days = 0
         is_partial = True
-    elapsed_pct = round(elapsed_days / days_in_month * 100) if days_in_month else 0
+    elapsed_pct = round(elapsed_days / total_days * 100) if total_days else 0
 
     # カテゴリ別支出
     cat_lines = []
@@ -299,10 +301,11 @@ def _build_cf_prompt(db_path: str, year_month: str) -> str:
     ]
 
     # 経過情報テキスト
+    period_info = f"{start_str}〜{end_str}（{total_days}日間）"
     if is_partial:
-        elapsed_text = f"■ 集計時点: {ym_year}年{ym_month}月{elapsed_days}日（{days_in_month}日中, 経過率{elapsed_pct}%）※月途中のデータ"
+        elapsed_text = f"■ 集計期間: {period_info}\n■ 経過: {elapsed_days}日目 / {total_days}日中（経過率{elapsed_pct}%）※月途中のデータ"
     else:
-        elapsed_text = f"■ 集計時点: {ym_year}年{ym_month}月（{days_in_month}日間, 月末確定データ）"
+        elapsed_text = f"■ 集計期間: {period_info}（月末確定データ）"
 
     data_text = f"""【家計簿データ ({year_month})】
 {elapsed_text}
@@ -326,7 +329,7 @@ def _build_cf_prompt(db_path: str, year_month: str) -> str:
     # 月途中の場合はペース分析を指示に含める
     if is_partial:
         pace_instruction = (
-            f"このデータは{ym_month}月{elapsed_days}日時点（経過率{elapsed_pct}%）の途中経過です。"
+            f"このデータは集計期間{total_days}日中{elapsed_days}日目（経過率{elapsed_pct}%）の途中経過です。"
             f"月末時点の支出見込み（日割りペース換算）や、予算に対する消化ペースが適正かどうか（経過率{elapsed_pct}%に対して消化率が高すぎないか）にも触れてください。"
         )
     else:

--- a/tests/test_ai_comment.py
+++ b/tests/test_ai_comment.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import date
 from unittest.mock import patch
 
 from src.analysis import ai_comment
@@ -79,18 +79,21 @@ def _setup_cf_db(db_path, year_month="2026-03"):
 
 
 def test_build_cf_prompt_includes_elapsed_days_for_current_month(tmp_path):
-    """当月データの場合、プロンプトに経過日数・経過率が含まれること。"""
+    """当月データの場合、プロンプトに経過日数・経過率が含まれること（closing_day=1）。"""
     db_path = _setup_cf_db(tmp_path / "assets.db", "2026-03")
 
-    # datetime.now() を 3月10日に固定
-    fake_now = datetime(2026, 3, 10, 12, 0, 0)
-    with patch("src.analysis.ai_comment.datetime") as mock_dt:
-        mock_dt.now.return_value = fake_now
-        mock_dt.side_effect = lambda *args, **kw: datetime(*args, **kw)
+    # date.today() を 3月10日に固定、fiscal month も "2026-03"
+    fake_today = date(2026, 3, 10)
+    with (
+        patch("src.analysis.ai_comment.date") as mock_date,
+        patch("src.analysis.ai_comment._current_fiscal_month", return_value="2026-03"),
+    ):
+        mock_date.today.return_value = fake_today
+        mock_date.fromisoformat = date.fromisoformat
         prompt = ai_comment._build_cf_prompt(db_path, "2026-03")
 
     assert "月途中のデータ" in prompt
-    assert "10日" in prompt
+    assert "10日目" in prompt
     assert "31日中" in prompt
     elapsed_pct = round(10 / 31 * 100)
     assert f"経過率{elapsed_pct}%" in prompt
@@ -101,12 +104,44 @@ def test_build_cf_prompt_past_month_is_confirmed(tmp_path):
     """過去月データの場合、月末確定データとして扱われること。"""
     db_path = _setup_cf_db(tmp_path / "assets.db", "2026-01")
 
-    fake_now = datetime(2026, 3, 10, 12, 0, 0)
-    with patch("src.analysis.ai_comment.datetime") as mock_dt:
-        mock_dt.now.return_value = fake_now
-        mock_dt.side_effect = lambda *args, **kw: datetime(*args, **kw)
+    fake_today = date(2026, 3, 10)
+    with (
+        patch("src.analysis.ai_comment.date") as mock_date,
+        patch("src.analysis.ai_comment._current_fiscal_month", return_value="2026-03"),
+    ):
+        mock_date.today.return_value = fake_today
+        mock_date.fromisoformat = date.fromisoformat
         prompt = ai_comment._build_cf_prompt(db_path, "2026-01")
 
     assert "月末確定データ" in prompt
     assert "月途中" not in prompt
     assert "日割りペース" not in prompt
+
+
+def test_build_cf_prompt_closing_day_25(tmp_path):
+    """締め日25日の場合、fiscal month の期間で経過日数が計算されること。"""
+    # closing_day=25: "2026-03" の期間は 2026-02-25 〜 2026-03-24（28日間）
+    db_path = _setup_cf_db(tmp_path / "assets.db", "2026-03")
+    conn = ai_comment.init_db(db_path)
+    conn.execute("INSERT OR REPLACE INTO settings (key, value) VALUES ('closing_day', '25')")
+    conn.commit()
+    conn.close()
+
+    # 今日=3/10、fiscal month="2026-03"、期間=2/25〜3/24
+    # 経過日数 = 3/10 - 2/25 + 1 = 14日目
+    fake_today = date(2026, 3, 10)
+    with (
+        patch("src.analysis.ai_comment.date") as mock_date,
+        patch("src.analysis.ai_comment._current_fiscal_month", return_value="2026-03"),
+    ):
+        mock_date.today.return_value = fake_today
+        mock_date.fromisoformat = date.fromisoformat
+        prompt = ai_comment._build_cf_prompt(db_path, "2026-03")
+
+    assert "月途中のデータ" in prompt
+    assert "14日目" in prompt
+    assert "28日中" in prompt
+    assert "2026-02-25" in prompt
+    assert "2026-03-24" in prompt
+    elapsed_pct = round(14 / 28 * 100)
+    assert f"経過率{elapsed_pct}%" in prompt


### PR DESCRIPTION
## Summary
- 家計簿AIプロンプトに集計時点の経過日数・経過率を追加
- 月途中データの場合、日割りペース換算や予算消化ペースの分析を指示
- 過去月は「月末確定データ」として従来通り扱う

## Test plan
- [x] 当月データで「月途中のデータ」「経過日数」「日割りペース」がプロンプトに含まれること
- [x] 過去月データで「月末確定データ」と表示され月途中の注記が出ないこと
- [x] 全215テスト通過
- [ ] 実際のAIコメントが経過日数を踏まえた内容になっているか目視確認

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)