### PR TITLE
カテゴリ別月次推移に直近平均を表示 (#50)

### DIFF
--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -940,7 +940,7 @@ def get_cf_category_trend(
     year_months = [r[0] for r in reversed(ym_rows)]
 
     if not year_months:
-        return {"year_months": [], "categories": [], "by_month": {}}
+        return {"year_months": [], "categories": [], "by_month": {}, "avg_by_category": {}, "avg_months": 0}
 
     rows = conn.execute(
         f"""SELECT {fm} as fm, major_category, SUM(amount) as total
@@ -960,10 +960,15 @@ def get_cf_category_trend(
     for r in rows:
         by_month.setdefault(r[0], {})[r[1]] = abs(r[2])
 
+    months_used = len(year_months)
+    avg_by_category = {cat: cat_totals[cat] / months_used for cat in categories}
+
     return {
         "year_months": year_months,
         "categories": categories,
         "by_month": by_month,
+        "avg_by_category": avg_by_category,
+        "avg_months": months_used,
     }
 
 

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -4716,6 +4716,10 @@ def _demo_cf_data() -> dict:
         "year_months": trend_months,
         "categories": demo_cats,
         "by_month": cat_by_month,
+        "avg_by_category": {
+            cat: sum(cat_by_month[m].get(cat, 0) for m in trend_months) / len(trend_months) for cat in demo_cats
+        },
+        "avg_months": len(trend_months),
     }
 
     # 固定費 vs 変動費デモデータ
@@ -4954,8 +4958,16 @@ def _build_cf_html(data: dict, skip_update: bool = False, ai_comment: str | None
     cat_trend_months = cat_trend.get("year_months", [])
     cat_trend_categories = cat_trend.get("categories", [])
     cat_trend_by_month = cat_trend.get("by_month", {})
+    cat_trend_avg_by_category = cat_trend.get("avg_by_category", {})
+    cat_trend_avg_months = int(cat_trend.get("avg_months", len(cat_trend_months) or 0))
     cat_trend_json = json.dumps(
-        {"months": cat_trend_months, "categories": cat_trend_categories, "by_month": cat_trend_by_month},
+        {
+            "months": cat_trend_months,
+            "categories": cat_trend_categories,
+            "by_month": cat_trend_by_month,
+            "avg_by_category": cat_trend_avg_by_category,
+            "avg_months": cat_trend_avg_months,
+        },
         ensure_ascii=False,
     )
 
@@ -4969,12 +4981,17 @@ def _build_cf_html(data: dict, skip_update: bool = False, ai_comment: str | None
         for cat in cat_trend_categories:
             cur = last_data.get(cat, 0)
             prev = prev_data.get(cat, 0)
+            avg = cat_trend_avg_by_category.get(cat, 0)
             diff = cur - prev
             if diff == 0 and cur == 0:
                 continue
             diff_sign = "+" if diff > 0 else ""
             diff_color = "color:#e74c3c" if diff > 0 else ("color:#2881D7" if diff < 0 else "")
-            diff_rows += f'<tr><td>{_h(cat)}</td><td class="num">{cur:,.0f}円</td><td class="num">{prev:,.0f}円</td><td class="num" style="{diff_color}">{diff_sign}{diff:,.0f}円</td></tr>'
+            diff_rows += (
+                f'<tr><td>{_h(cat)}</td><td class="num">{cur:,.0f}円</td>'
+                f'<td class="num">{prev:,.0f}円</td><td class="num">{avg:,.0f}円</td>'
+                f'<td class="num" style="{diff_color}">{diff_sign}{diff:,.0f}円</td></tr>'
+            )
 
     cat_trend_html = ""
     if cat_trend_months:
@@ -4989,7 +5006,7 @@ def _build_cf_html(data: dict, skip_update: bool = False, ai_comment: str | None
         {
             f'''<h3 style="font-size:0.95rem;margin:16px 0 8px;color:#636e72">{cat_trend_months[-1]} vs {cat_trend_months[-2]} 差分</h3>
         <table>
-          <tr><th>カテゴリ</th><th class="num">当月</th><th class="num">前月</th><th class="num">差分</th></tr>
+          <tr><th>カテゴリ</th><th class="num">当月</th><th class="num">前月</th><th class="num">直近{cat_trend_avg_months}ヶ月平均</th><th class="num">差分</th></tr>
           {diff_rows}
         </table>'''
             if len(cat_trend_months) >= 2

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -124,11 +124,18 @@ class TestCfCategoryTrend:
         assert result["by_month"]["2025-10"]["住宅"] == 85000
         assert result["by_month"]["2025-12"]["趣味・娯楽"] == 50000
 
+    def test_category_average_values(self, conn):
+        result = get_cf_category_trend(conn, months=6)
+        assert result["avg_months"] == 3
+        assert result["avg_by_category"]["住宅"] == 85000
+
     def test_empty_db(self, tmp_path):
         c = init_db(str(tmp_path / "empty.db"))
         result = get_cf_category_trend(c, months=6)
         assert result["year_months"] == []
         assert result["categories"] == []
+        assert result["avg_months"] == 0
+        assert result["avg_by_category"] == {}
         c.close()
 
 

--- a/tests/test_server_html.py
+++ b/tests/test_server_html.py
@@ -179,6 +179,7 @@ class TestCfCards:
     def test_category_trend_diff_table(self):
         """差分テーブルに前月比が含まれる。"""
         assert "差分" in self.html
+        assert "直近6ヶ月平均" in self.html
 
     def test_fixed_vs_variable(self):
         assert "固定費 vs 変動費" in self.html
@@ -350,6 +351,8 @@ class TestDemoData:
         assert len(ct["year_months"]) == 6
         assert len(ct["categories"]) > 0
         assert len(ct["by_month"]) == 6
+        assert ct["avg_months"] == 6
+        assert "住宅" in ct["avg_by_category"]
 
     def test_cf_fixed_expenses_structure(self):
         d = _demo_cf_data()


### PR DESCRIPTION
## 概要
- カテゴリ別月次推移データに avg_by_category と avg_months を追加
- 差分テーブルに 直近Nヶ月平均 列を追加
- デモデータとテストを更新

## テスト
- ./.venv/bin/pytest tests/test_repository.py tests/test_server_html.py -q

Closes #50