### PR TITLE
家計簿分析: カテゴリ別支出の詳細履歴を追加 (#51)

### DIFF
--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -972,6 +972,53 @@ def get_cf_category_trend(
     }
 
 
+def get_cf_category_details_history(
+    conn: sqlite3.Connection, months: int = 6, closing_day: int = 1, holiday_mode: str = "none"
+) -> dict:
+    """カテゴリ別に、直近Nヶ月の支出明細を返す。"""
+    fm = _fiscal_month_expr(closing_day, holiday_mode, conn)
+    cur_fm = _current_fiscal_month(closing_day, holiday_mode)
+    ym_rows = conn.execute(
+        f"""SELECT DISTINCT {fm} as fm FROM cf_transactions
+           WHERE is_transfer=0 AND is_target=1 AND amount<0
+           GROUP BY fm HAVING fm <= ?
+           ORDER BY fm DESC LIMIT ?""",
+        (cur_fm, months),
+    ).fetchall()
+    year_months = [r[0] for r in reversed(ym_rows)]
+    if not year_months:
+        return {"year_months": [], "categories": [], "by_category": {}}
+
+    rows = conn.execute(
+        f"""SELECT {fm} as fm, date, description, amount, major_category, minor_category, institution
+           FROM cf_transactions
+           WHERE is_transfer=0 AND is_target=1 AND amount<0
+             AND {fm} IN ({",".join("?" * len(year_months))})
+           ORDER BY fm DESC, amount ASC, date ASC""",
+        year_months,
+    ).fetchall()
+
+    by_category: dict[str, list[dict]] = {}
+    category_totals: dict[str, float] = {}
+    for r in rows:
+        major = r[4] or "未分類"
+        amt = abs(float(r[3]))
+        by_category.setdefault(major, []).append(
+            {
+                "year_month": r[0],
+                "date": r[1],
+                "description": r[2],
+                "amount": amt,
+                "minor_category": r[5] or "未分類",
+                "institution": r[6] or "",
+            }
+        )
+        category_totals[major] = category_totals.get(major, 0.0) + amt
+
+    categories = sorted(category_totals, key=lambda c: category_totals[c], reverse=True)
+    return {"year_months": year_months, "categories": categories, "by_category": by_category}
+
+
 def get_cf_fixed_expenses(
     conn: sqlite3.Connection, months: int = 3, closing_day: int = 1, holiday_mode: str = "none"
 ) -> dict:

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -309,18 +309,23 @@ _COLLAPSE_JS = """
   const saved = JSON.parse(localStorage.getItem('collapsed_cards') || '{}');
   document.querySelectorAll('[data-card-id]').forEach(card => {
     const id = card.dataset.cardId;
+    const defaultCollapsed = card.dataset.defaultCollapsed === 'true';
     const body = card.querySelector('.card-body');
     const btn = card.querySelector('.collapse-btn');
     if (!body || !btn) return;
-    if (saved[id]) {
+    const isCollapsed = Object.prototype.hasOwnProperty.call(saved, id) ? !!saved[id] : defaultCollapsed;
+    if (isCollapsed) {
       card.classList.add('collapsed');
       btn.textContent = '\\u25B6';
+    } else {
+      card.classList.remove('collapsed');
+      btn.textContent = '\\u25BC';
     }
     btn.addEventListener('click', () => {
-      const isCollapsed = card.classList.toggle('collapsed');
-      btn.textContent = isCollapsed ? '\\u25B6' : '\\u25BC';
+      const nextCollapsed = card.classList.toggle('collapsed');
+      btn.textContent = nextCollapsed ? '\\u25B6' : '\\u25BC';
       const s = JSON.parse(localStorage.getItem('collapsed_cards') || '{}');
-      if (isCollapsed) { s[id] = true; } else { delete s[id]; }
+      s[id] = nextCollapsed;
       localStorage.setItem('collapsed_cards', JSON.stringify(s));
     });
   });
@@ -5225,7 +5230,7 @@ def _build_cf_html(data: dict, skip_update: bool = False, ai_comment: str | None
     cat_details_html = ""
     if cat_detail_categories:
         cat_details_html = f"""
-    <div class="card full" data-card-id="cf-cat-details">
+    <div class="card full" data-card-id="cf-cat-details" data-default-collapsed="true">
       <div class="card-header">
         <h2>カテゴリ別支出の詳細（直近{len(cat_detail_months)}ヶ月）</h2>
         <button class="collapse-btn">&#x25BC;</button>
@@ -5234,11 +5239,19 @@ def _build_cf_html(data: dict, skip_update: bool = False, ai_comment: str | None
         <div style="display:flex;align-items:center;gap:10px;margin-bottom:10px">
           <label for="cat-detail-select" style="color:#636e72;font-size:0.9rem">カテゴリ</label>
           <select id="cat-detail-select" style="padding:6px 10px;border:1px solid #dfe6e9;border-radius:6px">{detail_options}</select>
+          <label for="cat-detail-sort" style="color:#636e72;font-size:0.9rem">並び順</label>
+          <select id="cat-detail-sort" style="padding:6px 10px;border:1px solid #dfe6e9;border-radius:6px">
+            <option value="month_amount">月→金額（既定）</option>
+            <option value="date_desc">日付（新しい順）</option>
+            <option value="date_asc">日付（古い順）</option>
+          </select>
         </div>
-        <table>
-          <tr><th>月</th><th>日付</th><th>内容</th><th>中項目</th><th>金融機関</th><th class="num">金額</th></tr>
-          <tbody id="cat-detail-rows"></tbody>
-        </table>
+        <div class="cat-detail-table-wrap">
+          <table class="cat-detail-table">
+            <tr><th class="col-month">月</th><th class="col-date">日付</th><th class="col-desc">内容</th><th class="col-minor">中項目</th><th class="col-inst">金融機関</th><th class="num col-amount">金額</th></tr>
+            <tbody id="cat-detail-rows"></tbody>
+          </table>
+        </div>
       </div>
     </div>"""
 
@@ -5464,6 +5477,15 @@ def _build_cf_html(data: dict, skip_update: bool = False, ai_comment: str | None
   .has-tip:hover {{ background: #f0f4ff; }}
   .pie-legend {{ font-size: 0.85rem; }}
   .pie-legend li {{ list-style: none; margin-bottom: 4px; }}
+  .cat-detail-table-wrap {{ max-height: 280px; overflow: auto; border: 1px solid #f1f2f6; border-radius: 8px; }}
+  .cat-detail-table {{ table-layout: fixed; width: 100%; min-width: 760px; }}
+  .cat-detail-table th, .cat-detail-table td {{ vertical-align: middle; }}
+  .cat-detail-table .col-month {{ width: 78px; white-space: nowrap; }}
+  .cat-detail-table .col-date {{ width: 68px; white-space: nowrap; }}
+  .cat-detail-table .col-minor {{ width: 84px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }}
+  .cat-detail-table .col-inst {{ width: 140px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }}
+  .cat-detail-table .col-amount {{ width: 98px; white-space: nowrap; }}
+  .cat-detail-table .col-desc {{ white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }}
   .dl-btn {{
     padding: 3px 10px; border: 1px solid #2881D7; border-radius: 4px;
     background: #fff; color: #2881D7; font-size: 0.8rem; cursor: pointer;
@@ -5560,8 +5582,6 @@ def _build_cf_html(data: dict, skip_update: bool = False, ai_comment: str | None
       </div>
     </div>
 
-    {cat_details_html}
-
     <div class="card" data-card-id="cf-top">
       <div class="card-header">
         <h2>{top_title}</h2>
@@ -5575,6 +5595,8 @@ def _build_cf_html(data: dict, skip_update: bool = False, ai_comment: str | None
         </table>
       </div>
     </div>
+
+    {cat_details_html}
 
     {cat_trend_html}
 
@@ -5716,11 +5738,24 @@ if (catTrendData.months.length > 0 && catTrendCanvas) {{
 // カテゴリ別支出の詳細（直近Nヶ月）
 const catDetailData = {cat_detail_json};
 const catDetailSelect = document.getElementById('cat-detail-select');
+const catDetailSort = document.getElementById('cat-detail-sort');
 const catDetailRows = document.getElementById('cat-detail-rows');
 
-function renderCategoryDetailRows(category) {{
+function renderCategoryDetailRows(category, sortMode) {{
   if (!catDetailRows) return;
-  const rows = (catDetailData.by_category || {{}})[category] || [];
+  const rows = [ ...((catDetailData.by_category || {{}})[category] || []) ];
+  if (sortMode === 'date_desc') {{
+    rows.sort((a, b) => (b.date || '').localeCompare(a.date || '') || Number(b.amount || 0) - Number(a.amount || 0));
+  }} else if (sortMode === 'date_asc') {{
+    rows.sort((a, b) => (a.date || '').localeCompare(b.date || '') || Number(b.amount || 0) - Number(a.amount || 0));
+  }} else {{
+    // default: fiscal month desc -> amount desc -> date desc
+    rows.sort((a, b) =>
+      (b.year_month || '').localeCompare(a.year_month || '') ||
+      Number(b.amount || 0) - Number(a.amount || 0) ||
+      (b.date || '').localeCompare(a.date || '')
+    );
+  }}
   if (!rows.length) {{
     catDetailRows.innerHTML = '<tr><td colspan="6" style="color:#999">明細データがありません</td></tr>';
     return;
@@ -5728,20 +5763,23 @@ function renderCategoryDetailRows(category) {{
   catDetailRows.innerHTML = rows.map(r => {{
     const dt = (r.date || '').slice(5);
     const inst = r.institution || '';
+    const desc = r.description || '';
+    const minor = r.minor_category || '';
     return '<tr>' +
-      '<td>' + esc(r.year_month || '') + '</td>' +
-      '<td>' + esc(dt) + '</td>' +
-      '<td>' + esc(r.description || '') + '</td>' +
-      '<td>' + esc(r.minor_category || '') + '</td>' +
-      '<td style="color:#636e72;font-size:0.82rem">' + esc(inst) + '</td>' +
-      '<td class="num">' + Number(r.amount || 0).toLocaleString('ja-JP') + '円</td>' +
+      '<td class="col-month">' + esc(r.year_month || '') + '</td>' +
+      '<td class="col-date">' + esc(dt) + '</td>' +
+      '<td class="col-desc" title="' + esc(desc) + '">' + esc(desc) + '</td>' +
+      '<td class="col-minor" title="' + esc(minor) + '">' + esc(minor) + '</td>' +
+      '<td class="col-inst" style="color:#636e72;font-size:0.82rem" title="' + esc(inst) + '">' + esc(inst) + '</td>' +
+      '<td class="num col-amount">' + Number(r.amount || 0).toLocaleString('ja-JP') + '円</td>' +
       '</tr>';
   }}).join('');
 }}
 
-if (catDetailSelect && catDetailRows) {{
-  renderCategoryDetailRows(catDetailSelect.value);
-  catDetailSelect.addEventListener('change', () => renderCategoryDetailRows(catDetailSelect.value));
+if (catDetailSelect && catDetailRows && catDetailSort) {{
+  renderCategoryDetailRows(catDetailSelect.value, catDetailSort.value);
+  catDetailSelect.addEventListener('change', () => renderCategoryDetailRows(catDetailSelect.value, catDetailSort.value));
+  catDetailSort.addEventListener('change', () => renderCategoryDetailRows(catDetailSelect.value, catDetailSort.value));
 }}
 
 // 月ナビゲーション

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -35,6 +35,7 @@ from src.db.repository import (
     get_cashflows,
     get_cf_actual_savings,
     get_cf_available_months,
+    get_cf_category_details_history,
     get_cf_category_summary,
     get_cf_category_trend,
     get_cf_dividend_history,
@@ -4575,6 +4576,9 @@ def _get_cf_data(db_path: str, year_month: str | None = None) -> dict:
 
         # カテゴリ別月次推移
         category_trend = get_cf_category_trend(conn, months=6, closing_day=closing_day, holiday_mode=holiday_mode)
+        category_details = get_cf_category_details_history(
+            conn, months=6, closing_day=closing_day, holiday_mode=holiday_mode
+        )
 
         # 固定費 vs 変動費
         fixed_expenses = get_cf_fixed_expenses(conn, months=3, closing_day=closing_day, holiday_mode=holiday_mode)
@@ -4596,6 +4600,7 @@ def _get_cf_data(db_path: str, year_month: str | None = None) -> dict:
         "trend": trend,
         "available_months": available,
         "category_trend": category_trend,
+        "category_details": category_details,
         "fixed_expenses": fixed_expenses,
         "income_breakdown": income_breakdown,
         "income_trend": income_trend,
@@ -4875,6 +4880,56 @@ def _demo_cf_data() -> dict:
         },
         "avg_months": len(trend_months),
     }
+    category_details = {
+        "year_months": trend_months,
+        "categories": demo_cats,
+        "by_category": {
+            "趣味・娯楽": [
+                {
+                    "year_month": trend_months[-1],
+                    "date": f"{trend_months[-1]}-03",
+                    "description": "Steam",
+                    "amount": 6200,
+                    "minor_category": "ゲーム",
+                    "institution": "楽天カード",
+                },
+                {
+                    "year_month": trend_months[-1],
+                    "date": f"{trend_months[-1]}-14",
+                    "description": "書籍",
+                    "amount": 5800,
+                    "minor_category": "書籍",
+                    "institution": "Amazon",
+                },
+                {
+                    "year_month": trend_months[-2],
+                    "date": f"{trend_months[-2]}-09",
+                    "description": "映画",
+                    "amount": 1900,
+                    "minor_category": "映画",
+                    "institution": "楽天カード",
+                },
+            ],
+            "食費": [
+                {
+                    "year_month": trend_months[-1],
+                    "date": f"{trend_months[-1]}-05",
+                    "description": "イオン",
+                    "amount": 12400,
+                    "minor_category": "食料品",
+                    "institution": "楽天カード",
+                },
+                {
+                    "year_month": trend_months[-2],
+                    "date": f"{trend_months[-2]}-19",
+                    "description": "外食",
+                    "amount": 4800,
+                    "minor_category": "外食",
+                    "institution": "三井住友カード",
+                },
+            ],
+        },
+    }
 
     # 固定費 vs 変動費デモデータ
     fixed_expenses = {
@@ -4921,6 +4976,7 @@ def _demo_cf_data() -> dict:
         "trend": trend,
         "available_months": available,
         "category_trend": category_trend,
+        "category_details": category_details,
         "fixed_expenses": fixed_expenses,
         "income_breakdown": income_breakdown,
         "income_trend": income_trend,
@@ -5155,6 +5211,36 @@ def _build_cf_html(data: dict, skip_update: bool = False, ai_comment: str | None
         },
         ensure_ascii=False,
     )
+
+    # --- カテゴリ別支出の明細（直近Nヶ月） ---
+    cat_details = data.get("category_details", {})
+    cat_detail_months = cat_details.get("year_months", [])
+    cat_detail_categories = cat_details.get("categories", [])
+    cat_detail_by_category = cat_details.get("by_category", {})
+    cat_detail_json = json.dumps(
+        {"months": cat_detail_months, "categories": cat_detail_categories, "by_category": cat_detail_by_category},
+        ensure_ascii=False,
+    )
+    detail_options = "".join(f'<option value="{_h(c)}">{_h(c)}</option>' for c in cat_detail_categories)
+    cat_details_html = ""
+    if cat_detail_categories:
+        cat_details_html = f"""
+    <div class="card full" data-card-id="cf-cat-details">
+      <div class="card-header">
+        <h2>カテゴリ別支出の詳細（直近{len(cat_detail_months)}ヶ月）</h2>
+        <button class="collapse-btn">&#x25BC;</button>
+      </div>
+      <div class="card-body">
+        <div style="display:flex;align-items:center;gap:10px;margin-bottom:10px">
+          <label for="cat-detail-select" style="color:#636e72;font-size:0.9rem">カテゴリ</label>
+          <select id="cat-detail-select" style="padding:6px 10px;border:1px solid #dfe6e9;border-radius:6px">{detail_options}</select>
+        </div>
+        <table>
+          <tr><th>月</th><th>日付</th><th>内容</th><th>中項目</th><th>金融機関</th><th class="num">金額</th></tr>
+          <tbody id="cat-detail-rows"></tbody>
+        </table>
+      </div>
+    </div>"""
 
     # 差分テーブル
     diff_rows = ""
@@ -5474,6 +5560,8 @@ def _build_cf_html(data: dict, skip_update: bool = False, ai_comment: str | None
       </div>
     </div>
 
+    {cat_details_html}
+
     <div class="card" data-card-id="cf-top">
       <div class="card-header">
         <h2>{top_title}</h2>
@@ -5623,6 +5711,37 @@ if (catTrendData.months.length > 0 && catTrendCanvas) {{
     ctx2.fillStyle = '#b2bec3';
     ctx2.fillText('…他' + (cCats.length - 6) + '件', lx, 15);
   }}
+}}
+
+// カテゴリ別支出の詳細（直近Nヶ月）
+const catDetailData = {cat_detail_json};
+const catDetailSelect = document.getElementById('cat-detail-select');
+const catDetailRows = document.getElementById('cat-detail-rows');
+
+function renderCategoryDetailRows(category) {{
+  if (!catDetailRows) return;
+  const rows = (catDetailData.by_category || {{}})[category] || [];
+  if (!rows.length) {{
+    catDetailRows.innerHTML = '<tr><td colspan="6" style="color:#999">明細データがありません</td></tr>';
+    return;
+  }}
+  catDetailRows.innerHTML = rows.map(r => {{
+    const dt = (r.date || '').slice(5);
+    const inst = r.institution || '';
+    return '<tr>' +
+      '<td>' + esc(r.year_month || '') + '</td>' +
+      '<td>' + esc(dt) + '</td>' +
+      '<td>' + esc(r.description || '') + '</td>' +
+      '<td>' + esc(r.minor_category || '') + '</td>' +
+      '<td style="color:#636e72;font-size:0.82rem">' + esc(inst) + '</td>' +
+      '<td class="num">' + Number(r.amount || 0).toLocaleString('ja-JP') + '円</td>' +
+      '</tr>';
+  }}).join('');
+}}
+
+if (catDetailSelect && catDetailRows) {{
+  renderCategoryDetailRows(catDetailSelect.value);
+  catDetailSelect.addEventListener('change', () => renderCategoryDetailRows(catDetailSelect.value));
 }}
 
 // 月ナビゲーション

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -22,6 +22,7 @@ from src.db.repository import (
     get_annual_life_event_expenses,
     get_cf_actual_savings,
     get_cf_available_months,
+    get_cf_category_details_history,
     get_cf_category_summary,
     get_cf_category_trend,
     get_cf_dividend_history,
@@ -136,6 +137,32 @@ class TestCfCategoryTrend:
         assert result["categories"] == []
         assert result["avg_months"] == 0
         assert result["avg_by_category"] == {}
+        c.close()
+
+
+class TestCfCategoryDetailsHistory:
+    def test_returns_category_details(self, conn):
+        result = get_cf_category_details_history(conn, months=6)
+        assert result["year_months"] == ["2025-10", "2025-11", "2025-12"]
+        assert "住宅" in result["categories"]
+        assert len(result["by_category"]["住宅"]) >= 1
+
+    def test_detail_row_shape(self, conn):
+        result = get_cf_category_details_history(conn, months=6)
+        row = result["by_category"]["食費"][0]
+        assert "year_month" in row
+        assert "date" in row
+        assert "description" in row
+        assert "amount" in row
+        assert "minor_category" in row
+        assert "institution" in row
+
+    def test_empty_db(self, tmp_path):
+        c = init_db(str(tmp_path / "empty.db"))
+        result = get_cf_category_details_history(c, months=6)
+        assert result["year_months"] == []
+        assert result["categories"] == []
+        assert result["by_category"] == {}
         c.close()
 
 

--- a/tests/test_server_html.py
+++ b/tests/test_server_html.py
@@ -124,7 +124,16 @@ class TestCollapse:
         """全CFカードに data-card-id と collapse-btn がある。"""
         html = _build_cf_html(_demo_cf_data())
         card_ids = re.findall(r'data-card-id="([^"]+)"', html)
-        expected = {"cf-category", "cf-top", "cf-cat-trend", "cf-fixed", "cf-income", "cf-trend", "cf-download"}
+        expected = {
+            "cf-category",
+            "cf-cat-details",
+            "cf-top",
+            "cf-cat-trend",
+            "cf-fixed",
+            "cf-income",
+            "cf-trend",
+            "cf-download",
+        }
         assert expected.issubset(set(card_ids)), f"Missing: {expected - set(card_ids)}"
         # 各カードに collapse-btn がある
         for cid in expected:
@@ -207,6 +216,11 @@ class TestCfCards:
 
     def test_download_management(self):
         assert "過去月ダウンロード管理" in self.html
+
+    def test_category_details_card(self):
+        assert "カテゴリ別支出の詳細" in self.html
+        assert 'id="cat-detail-select"' in self.html
+        assert 'id="cat-detail-rows"' in self.html
 
     def test_top_expenses_filtered_label(self):
         assert "高額支出 TOP15（生活支出）" in self.html
@@ -378,6 +392,7 @@ class TestDemoData:
             "trend",
             "available_months",
             "category_trend",
+            "category_details",
             "fixed_expenses",
             "income_breakdown",
             "income_trend",
@@ -392,6 +407,13 @@ class TestDemoData:
         assert len(ct["by_month"]) == 6
         assert ct["avg_months"] == 6
         assert "住宅" in ct["avg_by_category"]
+
+    def test_cf_category_details_structure(self):
+        d = _demo_cf_data()
+        cd = d["category_details"]
+        assert len(cd["year_months"]) == 6
+        assert "趣味・娯楽" in cd["categories"]
+        assert len(cd["by_category"]["趣味・娯楽"]) > 0
 
     def test_cf_fixed_expenses_structure(self):
         d = _demo_cf_data()

--- a/tests/test_server_html.py
+++ b/tests/test_server_html.py
@@ -220,7 +220,12 @@ class TestCfCards:
     def test_category_details_card(self):
         assert "カテゴリ別支出の詳細" in self.html
         assert 'id="cat-detail-select"' in self.html
+        assert 'id="cat-detail-sort"' in self.html
+        assert "日付（新しい順）" in self.html
+        assert "日付（古い順）" in self.html
         assert 'id="cat-detail-rows"' in self.html
+        assert 'data-card-id="cf-cat-details" data-default-collapsed="true"' in self.html
+        assert 'class="cat-detail-table"' in self.html
 
     def test_top_expenses_filtered_label(self):
         assert "高額支出 TOP15（生活支出）" in self.html


### PR DESCRIPTION
## 概要
- カテゴリ別支出カードに連動する「カテゴリ別支出の詳細（直近6ヶ月）」カードを追加
- カテゴリ選択で、月ごとの支出明細（日付/内容/中項目/金融機関/金額）を表示
- repository にカテゴリ別支出履歴取得関数を追加
- デモデータ・テストを更新

## テスト
- ./.venv/bin/pytest tests/test_repository.py tests/test_server_html.py -q

Closes #51