### PR TITLE
静的HTML生成をdist化しCloudflare Pages導線を追加 (#54)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -27,11 +27,11 @@ jobs:
           python -m pip install -e ".[dev]"
 
       - name: Build static pages
-        run: python -m scripts.build_static
+        run: python -m scripts.build_static --mode demo --output dist
 
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          publish_dir: ./dist
           force_orphan: true

--- a/README.md
+++ b/README.md
@@ -162,6 +162,32 @@ python -m src.cli.report
 python -m src.web.server --demo
 ```
 
+### 10. 静的HTMLビルドと Cloudflare Pages デプロイ
+
+`dist/` に静的HTMLを生成し、Cloudflare Pages（または GitHub Pages）に公開できる。
+
+```bash
+# デモデータで静的HTML生成（GitHub Pages 用デモバナー付き）
+python -m scripts.build_static --mode demo --output dist
+
+# 実データで静的HTML生成（バナーなし、本人閲覧用）
+python -m scripts.build_static --mode live --db-path data/assets.db --output dist
+
+# 日次取得→ビルド→Cloudflare Pages デプロイを一括実行
+python -m src.daily --build-static --deploy --deploy-project-name <PROJECT_NAME>
+```
+
+**Cloudflare Pages デプロイの前提**:
+
+- `wrangler` CLI が PATH 上にあること（`npm install -g wrangler` または `npx wrangler`）
+- 以下のいずれかで Cloudflare の認証を済ませておく:
+  - `wrangler login` で対話的にログイン（推奨）
+  - 環境変数 `CLOUDFLARE_API_TOKEN`（および必要なら `CLOUDFLARE_ACCOUNT_ID`）を設定（CI 用）
+- `--deploy-project-name` で Cloudflare Pages の project name を指定（省略時は wrangler のデフォルト挙動）
+- 認証失敗・wrangler 未インストール時はビルド成果物（`dist/`）は残るが、デプロイのみが失敗する
+
+> ⚠️ `--mode live` は `dist/` に実データを書き出すため、生成物を**そのまま公開リポジトリにコミットしない**こと。Cloudflare Pages 経由でのみ配信する想定。
+
 ## プロジェクト構成
 
 ```

--- a/scripts/build_static.py
+++ b/scripts/build_static.py
@@ -1,14 +1,17 @@
-"""GitHub Pages 用の静的 HTML を生成するビルドスクリプト。
+"""静的 HTML を生成するビルドスクリプト。
 
-既存の _demo_*_data() + _build_*_html() を呼び出して docs/ に出力する。
+既存の _build_*_html() を流用して dist/（または指定先）に出力する。
 シミュレーターページは fetch('/api/simulator') を JS Monte Carlo に置き換える。
 
 Usage:
-    python scripts/build_static.py
+    python -m scripts.build_static
+    python -m scripts.build_static --mode demo --output dist
+    python -m scripts.build_static --mode live --db-path data/assets.db --output dist
 """
 
 from __future__ import annotations
 
+import argparse
 import re
 import shutil
 from pathlib import Path
@@ -23,9 +26,14 @@ from src.web.server import (
     _demo_data,
     _demo_plan_data,
     _demo_simulator_data,
+    _get_cf_data,
+    _get_data,
+    _get_dates,
+    _get_plan_data,
+    _get_simulator_data,
 )
 
-DOCS_DIR = Path(__file__).resolve().parents[1] / "docs"
+DOCS_DIR = Path(__file__).resolve().parents[1] / "dist"
 REPO_URL = "https://github.com/hide10/asset-dashboard"
 
 # GitHub Pages 用デモバナー
@@ -252,10 +260,11 @@ def _inject_banner(html: str) -> str:
     return html.replace("<body>", "<body>\n" + _STATIC_BANNER, 1)
 
 
-def _postprocess_common(html: str) -> str:
+def _postprocess_common(html: str, include_banner: bool = True) -> str:
     """全ページ共通の後処理。"""
     html = _rewrite_nav_links(html)
-    html = _inject_banner(html)
+    if include_banner:
+        html = _inject_banner(html)
     return html
 
 
@@ -391,65 +400,90 @@ def _postprocess_plan(html: str) -> str:
     return html
 
 
-def build() -> Path:
-    """静的 HTML をビルドして docs/ に出力する。"""
-    # docs/ をクリーンアップして再作成
-    if DOCS_DIR.exists():
-        shutil.rmtree(DOCS_DIR)
-    DOCS_DIR.mkdir(parents=True)
+def build(output_dir: Path | None = None, mode: str = "demo", db_path: str = "data/assets.db") -> Path:
+    """静的 HTML をビルドして output_dir に出力する。"""
+    target = output_dir or DOCS_DIR
+    is_demo = mode == "demo"
+
+    # output_dir をクリーンアップして再作成
+    if target.exists():
+        shutil.rmtree(target)
+    target.mkdir(parents=True)
 
     # .nojekyll を作成
-    (DOCS_DIR / ".nojekyll").touch()
+    (target / ".nojekyll").touch()
 
-    # --- ダッシュボード ---
-    dash_data = _demo_data()
-    dash_dates = [dash_data["date"]]
-    ai_comment = (
-        "総資産約2,150万円のポートフォリオは、株式・投資信託・預金・年金にバランスよく分散されています。"
-        "前日比+4.2万円、前月比+28.5万円と堅調に推移しており、特にリスク資産（株式+投信）の貢献が大きいです。"
-        "年間配当予測は約12.5万円（利回り約1.9%）で、高配当銘柄の追加や業種の偏り（電気機器が大きい）"
-        "の分散を検討すると、より安定したポートフォリオになるでしょう。"
-    )
-    dash_html = _build_html(dash_data, dash_dates, skip_update=True, ai_comment=ai_comment, demo=True)
-    dash_html = _postprocess_common(dash_html)
-    (DOCS_DIR / "index.html").write_text(dash_html, encoding="utf-8")
+    if is_demo:
+        # --- ダッシュボード（demo） ---
+        dash_data = _demo_data()
+        dash_dates = [dash_data["date"]]
+        ai_comment = (
+            "総資産約2,150万円のポートフォリオは、株式・投資信託・預金・年金にバランスよく分散されています。"
+            "前日比+4.2万円、前月比+28.5万円と堅調に推移しており、特にリスク資産（株式+投信）の貢献が大きいです。"
+            "年間配当予測は約12.5万円（利回り約1.9%）で、高配当銘柄の追加や業種の偏り（電気機器が大きい）"
+            "の分散を検討すると、より安定したポートフォリオになるでしょう。"
+        )
+        dash_html = _build_html(dash_data, dash_dates, skip_update=True, ai_comment=ai_comment, demo=True)
+    else:
+        # --- ダッシュボード（live） ---
+        dash_data = _get_data(db_path)
+        dash_dates = _get_dates(db_path)
+        if not dash_data:
+            raise RuntimeError("ダッシュボード用データがありません。先に src.daily を実行してください。")
+        dash_html = _build_html(dash_data, dash_dates, skip_update=True, ai_comment=None, demo=False)
+    dash_html = _postprocess_common(dash_html, include_banner=is_demo)
+    (target / "index.html").write_text(dash_html, encoding="utf-8")
 
     # --- 家計簿分析 ---
-    cf_data = _demo_cf_data()
-    cf_ai = (
-        "今月の支出は食費と日用品が予算を若干上回っていますが、全体では収支プラスを維持しています。"
-        "固定費率は約40%と標準的で、通信費や保険の見直し余地があります。"
-        "来月は食費の予算管理を意識すると、さらに貯蓄率を改善できるでしょう。"
-    )
-    cf_html = _build_cf_html(cf_data, skip_update=True, ai_comment=cf_ai)
-    cf_html = _postprocess_common(cf_html)
-    (DOCS_DIR / "cf.html").write_text(cf_html, encoding="utf-8")
+    if is_demo:
+        cf_data = _demo_cf_data()
+        cf_ai = (
+            "今月の支出は食費と日用品が予算を若干上回っていますが、全体では収支プラスを維持しています。"
+            "固定費率は約40%と標準的で、通信費や保険の見直し余地があります。"
+            "来月は食費の予算管理を意識すると、さらに貯蓄率を改善できるでしょう。"
+        )
+        cf_html = _build_cf_html(cf_data, skip_update=True, ai_comment=cf_ai)
+    else:
+        cf_data = _get_cf_data(db_path)
+        cf_html = _build_cf_html(cf_data, skip_update=True, ai_comment=None)
+    cf_html = _postprocess_common(cf_html, include_banner=is_demo)
+    (target / "cf.html").write_text(cf_html, encoding="utf-8")
 
     # --- ライフプラン ---
-    plan_data = _demo_plan_data()
-    plan_ai = (
-        "直近6ヶ月で資産は約1,970万円から2,150万円へ着実に増加しており、月平均+30万円の成長ペースです。"
-        "月次収支は概ね黒字を維持していますが、12月のように支出が膨らむ月もあるため、"
-        "臨時出費への備えも意識しましょう。モンテカルロ・シミュレーションでは、月5万円の積立を継続した場合、"
-        "5年後の中央値は約3,120万円と見込まれ、長期的な資産形成は順調と言えます。"
-    )
-    plan_html = _build_plan_html(plan_data, skip_update=True, ai_comment=plan_ai)
-    plan_html = _postprocess_common(plan_html)
+    if is_demo:
+        plan_data = _demo_plan_data()
+        plan_ai = (
+            "直近6ヶ月で資産は約1,970万円から2,150万円へ着実に増加しており、月平均+30万円の成長ペースです。"
+            "月次収支は概ね黒字を維持していますが、12月のように支出が膨らむ月もあるため、"
+            "臨時出費への備えも意識しましょう。モンテカルロ・シミュレーションでは、月5万円の積立を継続した場合、"
+            "5年後の中央値は約3,120万円と見込まれ、長期的な資産形成は順調と言えます。"
+        )
+        plan_html = _build_plan_html(plan_data, skip_update=True, ai_comment=plan_ai)
+    else:
+        plan_data = _get_plan_data(db_path)
+        plan_html = _build_plan_html(plan_data, skip_update=True, ai_comment=None)
+    plan_html = _postprocess_common(plan_html, include_banner=is_demo)
     plan_html = _postprocess_plan(plan_html)
-    (DOCS_DIR / "plan.html").write_text(plan_html, encoding="utf-8")
+    (target / "plan.html").write_text(plan_html, encoding="utf-8")
 
     # --- シミュレーター ---
-    sim_data = _demo_simulator_data()
+    sim_data = _demo_simulator_data() if is_demo else _get_simulator_data(db_path)
     sim_html = _build_simulator_html(sim_data, skip_update=True)
-    sim_html = _postprocess_common(sim_html)
+    sim_html = _postprocess_common(sim_html, include_banner=is_demo)
     sim_html = _postprocess_simulator(sim_html)
-    (DOCS_DIR / "simulator.html").write_text(sim_html, encoding="utf-8")
+    (target / "simulator.html").write_text(sim_html, encoding="utf-8")
 
-    return DOCS_DIR
+    return target
 
 
 if __name__ == "__main__":
-    output = build()
+    parser = argparse.ArgumentParser(description="静的HTMLビルド")
+    parser.add_argument("--output", type=Path, default=DOCS_DIR, help="出力先ディレクトリ（デフォルト: dist/）")
+    parser.add_argument("--mode", choices=["demo", "live"], default="demo", help="demo か live を選択")
+    parser.add_argument("--db-path", type=str, default="data/assets.db", help="live モードで読むDBパス")
+    args = parser.parse_args()
+
+    output = build(output_dir=args.output, mode=args.mode, db_path=args.db_path)
     files = sorted(output.iterdir())
     print(f"Built {len(files)} files in {output}/:")
     for f in files:

--- a/scripts/build_static.py
+++ b/scripts/build_static.py
@@ -473,6 +473,8 @@ def build(output_dir: Path | None = None, mode: str = "demo", db_path: str = "da
         cf_html = _build_cf_html(cf_data, skip_update=True, ai_comment=cf_ai)
     else:
         cf_data = _get_cf_data(db_path)
+        if not cf_data:
+            raise RuntimeError("家計簿用データがありません。先に家計簿CSVを取得してください。")
         cf_html = _build_cf_html(cf_data, skip_update=True, ai_comment=None)
     cf_html = _postprocess_common(cf_html, include_banner=is_demo)
     (target / "cf.html").write_text(cf_html, encoding="utf-8")
@@ -489,6 +491,8 @@ def build(output_dir: Path | None = None, mode: str = "demo", db_path: str = "da
         plan_html = _build_plan_html(plan_data, skip_update=True, ai_comment=plan_ai)
     else:
         plan_data = _get_plan_data(db_path)
+        if not plan_data:
+            raise RuntimeError("ライフプラン用データがありません。先に src.daily を実行してください。")
         plan_html = _build_plan_html(plan_data, skip_update=True, ai_comment=None)
     plan_html = _postprocess_common(plan_html, include_banner=is_demo)
     plan_html = _postprocess_plan(plan_html)

--- a/scripts/build_static.py
+++ b/scripts/build_static.py
@@ -34,6 +34,7 @@ from src.web.server import (
 )
 
 DOCS_DIR = Path(__file__).resolve().parents[1] / "dist"
+REPO_ROOT = Path(__file__).resolve().parents[1]
 REPO_URL = "https://github.com/hide10/asset-dashboard"
 
 # GitHub Pages 用デモバナー
@@ -400,15 +401,42 @@ def _postprocess_plan(html: str) -> str:
     return html
 
 
+def _prepare_output_dir(output_dir: Path) -> Path:
+    """出力先を安全に初期化する。
+
+    デフォルトの dist/ は生成物として削除してよいが、任意指定された
+    空でない既存ディレクトリは誤削除を避けるため拒否する。
+    """
+    target = output_dir.resolve()
+    default_target = DOCS_DIR.resolve()
+    dangerous_targets = {
+        REPO_ROOT.resolve(),
+        REPO_ROOT.resolve().parent,
+        Path.home().resolve(),
+        Path("/").resolve(),
+        Path.cwd().resolve(),
+    }
+    if target in dangerous_targets:
+        raise ValueError(f"危険な出力先です: {target}")
+
+    if target.exists():
+        if not target.is_dir():
+            raise ValueError(f"出力先がディレクトリではありません: {target}")
+        if any(target.iterdir()):
+            if target != default_target:
+                raise ValueError(f"出力先が空ではありません。既存ファイルを保護するため削除しません: {target}")
+            shutil.rmtree(target)
+        else:
+            target.rmdir()
+
+    target.mkdir(parents=True)
+    return target
+
+
 def build(output_dir: Path | None = None, mode: str = "demo", db_path: str = "data/assets.db") -> Path:
     """静的 HTML をビルドして output_dir に出力する。"""
-    target = output_dir or DOCS_DIR
+    target = _prepare_output_dir(output_dir or DOCS_DIR)
     is_demo = mode == "demo"
-
-    # output_dir をクリーンアップして再作成
-    if target.exists():
-        shutil.rmtree(target)
-    target.mkdir(parents=True)
 
     # .nojekyll を作成
     (target / ".nojekyll").touch()

--- a/src/daily.py
+++ b/src/daily.py
@@ -213,10 +213,10 @@ def main() -> None:
             args.storage_state,
             args.wait,
             not args.no_refresh,
-            False,
-            args.build_static,
-            args.deploy,
-            args.deploy_project_name,
+            headless=False,
+            build_static=args.build_static,
+            deploy=args.deploy,
+            deploy_project_name=args.deploy_project_name,
         )
     )
 

--- a/src/daily.py
+++ b/src/daily.py
@@ -30,6 +30,24 @@ from src.parser.normalize import AssetSnapshot, parse_raw
 from src.scraper.fetch import create_context, fetch_cf_csv, fetch_monthly, fetch_page, request_aggregation
 
 
+def _deploy_cloudflare_pages(out_dir: Path, deploy_project_name: str | None = None) -> None:
+    """Cloudflare Pages へ静的HTMLをデプロイする。失敗時は例外で呼び出し元に返す。"""
+    cmd = ["wrangler", "pages", "deploy", str(out_dir)]
+    if deploy_project_name:
+        cmd += ["--project-name", deploy_project_name]
+    print("Cloudflare Pages へデプロイします...")
+    print(" ", " ".join(cmd))
+    try:
+        subprocess.run(cmd, check=True)
+        print("  Cloudflare Pages デプロイ完了")
+    except FileNotFoundError as e:
+        print("  wrangler コマンドが見つかりません。npm で wrangler をインストールしてください。")
+        raise RuntimeError("wrangler コマンドが見つからないためデプロイできません") from e
+    except subprocess.CalledProcessError as e:
+        print(f"  デプロイ失敗（exit={e.returncode}）")
+        raise
+
+
 def _is_unchanged(current: AssetSnapshot, previous: dict) -> bool:
     """前回スナップショットとデータが変わっていないか判定する。
 
@@ -172,18 +190,7 @@ async def run(
             print(f"  静的HTML生成完了: {out_dir}")
 
             if deploy:
-                cmd = ["wrangler", "pages", "deploy", str(out_dir)]
-                if deploy_project_name:
-                    cmd += ["--project-name", deploy_project_name]
-                print("Cloudflare Pages へデプロイします...")
-                print(" ", " ".join(cmd))
-                try:
-                    subprocess.run(cmd, check=True)
-                    print("  Cloudflare Pages デプロイ完了")
-                except FileNotFoundError:
-                    print("  wrangler コマンドが見つかりません。npm で wrangler をインストールしてください。")
-                except subprocess.CalledProcessError as e:
-                    print(f"  デプロイ失敗（exit={e.returncode}）")
+                _deploy_cloudflare_pages(out_dir, deploy_project_name)
 
     finally:
         await browser.close()

--- a/src/daily.py
+++ b/src/daily.py
@@ -4,12 +4,16 @@
     python -m src.daily                    # デフォルト（更新待ち60秒）
     python -m src.daily --wait 30          # 更新待ち30秒
     python -m src.daily --no-refresh       # 一括更新を行わない（従来動作）
+    python -m src.daily --build-static     # dist/ に静的HTMLを生成
+    python -m src.daily --deploy --deploy-project-name <name>  # Cloudflare Pagesへデプロイ
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import subprocess
+from pathlib import Path
 
 from src.db.repository import (
     get_snapshot,
@@ -42,6 +46,9 @@ async def run(
     wait_seconds: int = 60,
     enable_refresh: bool = True,
     headless: bool = False,
+    build_static: bool = False,
+    deploy: bool = False,
+    deploy_project_name: str | None = None,
 ) -> None:
     pw, browser, context = await create_context(storage_state, headless=headless, accept_downloads=True)
     try:
@@ -156,6 +163,28 @@ async def run(
             print(f"  家計簿CSV: {len(cf_transactions)}件をDB保存")
         conn.close()
 
+        # 7. 静的HTMLビルド / Cloudflare Pages デプロイ（任意）
+        if build_static or deploy:
+            print("\n静的HTMLを生成します（dist/）...")
+            from scripts.build_static import build as build_static_pages
+
+            out_dir = build_static_pages(output_dir=Path("dist"), mode="live", db_path="data/assets.db")
+            print(f"  静的HTML生成完了: {out_dir}")
+
+            if deploy:
+                cmd = ["wrangler", "pages", "deploy", str(out_dir)]
+                if deploy_project_name:
+                    cmd += ["--project-name", deploy_project_name]
+                print("Cloudflare Pages へデプロイします...")
+                print(" ", " ".join(cmd))
+                try:
+                    subprocess.run(cmd, check=True)
+                    print("  Cloudflare Pages デプロイ完了")
+                except FileNotFoundError:
+                    print("  wrangler コマンドが見つかりません。npm で wrangler をインストールしてください。")
+                except subprocess.CalledProcessError as e:
+                    print(f"  デプロイ失敗（exit={e.returncode}）")
+
     finally:
         await browser.close()
         await pw.stop()
@@ -166,8 +195,23 @@ def main() -> None:
     parser.add_argument("--storage-state", type=str, default=None)
     parser.add_argument("--wait", type=int, default=60, help="一括更新後の待機秒数（デフォルト: 60）")
     parser.add_argument("--no-refresh", action="store_true", help="データ未更新時の一括更新を行わない")
+    parser.add_argument("--build-static", action="store_true", help="処理後に dist/ へ静的HTMLを生成する")
+    parser.add_argument(
+        "--deploy", action="store_true", help="処理後に Cloudflare Pages へデプロイする（wrangler 必須）"
+    )
+    parser.add_argument("--deploy-project-name", type=str, default=None, help="Cloudflare Pages の project name")
     args = parser.parse_args()
-    asyncio.run(run(args.storage_state, args.wait, not args.no_refresh))
+    asyncio.run(
+        run(
+            args.storage_state,
+            args.wait,
+            not args.no_refresh,
+            False,
+            args.build_static,
+            args.deploy,
+            args.deploy_project_name,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -2642,7 +2642,7 @@ def _build_simulator_html(data: dict, skip_update: bool = False) -> str:
     impact_color = "#e74c3c" if net_impact < 0 else "#0F7F30"
 
     summary_html = f"""
-    <div class="card full" data-card-id="sim-summary">
+    <div class="card full sim-summary-card" data-card-id="sim-summary">
       <div class="card-header">
         <h2>財務サマリー</h2>
         <button class="collapse-btn">&#x25BC;</button>
@@ -2883,13 +2883,13 @@ def _build_simulator_html(data: dict, skip_update: bool = False) -> str:
     balances_json = json.dumps(result.yearly_balances, ensure_ascii=False)
     balances_no_events_json = json.dumps(result_no_events.yearly_balances, ensure_ascii=False)
     chart_html = """
-    <div class="card full" data-card-id="sim-chart">
+    <div class="card full sim-chart-card" data-card-id="sim-chart">
       <div class="card-header">
         <h2>資産推移グラフ</h2>
         <button class="collapse-btn">&#x25BC;</button>
       </div>
       <div class="card-body">
-      <div style="position:relative;width:100%;padding-bottom:45%;min-height:280px">
+      <div class="sim-chart-frame">
         <canvas id="sim-fan-chart" style="position:absolute;top:0;left:0;width:100%;height:100%"></canvas>
       </div>
       <div class="pred-note">※ 実質値（インフレ調整済み）。濃い帯=P25〜P75、薄い帯=P10〜P90、線=P50（中央値）</div>
@@ -2928,10 +2928,14 @@ def _build_simulator_html(data: dict, skip_update: bool = False) -> str:
   {_NAV_CSS}
   h1 {{ font-size: 1.5rem; }}
   .grid {{ display: flex; flex-wrap: wrap; gap: 20px; align-items: flex-start; }}
-  [data-card-id="sim-chart"] {{
+  .sim-overview-stack {{
     position: sticky;
     top: 12px;
-    z-index: 3;
+    z-index: 4;
+    display: grid;
+    gap: 12px;
+    width: 100%;
+    flex: 0 0 100%;
   }}
   .card {{
     background: #fff; border-radius: 12px; padding: 20px;
@@ -3028,14 +3032,29 @@ def _build_simulator_html(data: dict, skip_update: bool = False) -> str:
     font-size: 0.8rem !important; padding: 8px 16px !important;
   }}
   .sim-reset-btn:hover {{ background: #f8f9fa !important; color: #2d3436 !important; }}
-  .sim-summary-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; margin-bottom: 16px; }}
-  .sim-summary-item {{ text-align: center; padding: 12px; background: #f8f9fa; border-radius: 8px; }}
-  .sim-summary-label {{ font-size: 0.8rem; color: #636e72; margin-bottom: 4px; }}
-  .sim-summary-value {{ font-size: 1.1rem; font-weight: 700; }}
-  .sim-prob-grid {{ display: flex; gap: 24px; justify-content: center; padding: 12px 0; border-top: 1px solid #f1f2f6; }}
+  .sim-summary-card {{
+    padding: 14px 16px;
+    background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+    border: 1px solid #e8f1fb;
+  }}
+  .sim-summary-card .card-header,
+  .sim-chart-card .card-header {{
+    margin-bottom: 10px;
+  }}
+  .sim-summary-grid {{ display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; margin-bottom: 12px; }}
+  .sim-summary-item {{
+    text-align: left; padding: 10px 12px; background: rgba(248,249,250,0.92); border-radius: 10px;
+    border: 1px solid #eef2f7;
+  }}
+  .sim-summary-label {{ font-size: 0.74rem; color: #636e72; margin-bottom: 4px; line-height: 1.4; }}
+  .sim-summary-value {{ font-size: 1rem; font-weight: 700; line-height: 1.25; }}
+  .sim-prob-grid {{
+    display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px;
+    padding-top: 12px; border-top: 1px solid #f1f2f6;
+  }}
   .sim-prob-item {{ text-align: center; }}
-  .sim-prob-label {{ font-size: 0.8rem; color: #636e72; margin-right: 8px; }}
-  .sim-prob-value {{ font-size: 1.2rem; font-weight: 700; }}
+  .sim-prob-label {{ display: block; font-size: 0.74rem; color: #636e72; margin-bottom: 2px; }}
+  .sim-prob-value {{ font-size: 1.05rem; font-weight: 700; }}
   .sim-loading {{ display: none; margin-left: 8px; }}
   .sim-notes {{
     margin-top: 16px; padding: 0; background: #f8f9fa; border-radius: 8px;
@@ -3059,15 +3078,27 @@ def _build_simulator_html(data: dict, skip_update: bool = False) -> str:
   .sim-notes ul {{ font-size: 0.75rem; color: #636e72; padding-left: 18px; margin: 0; }}
   .sim-notes li {{ margin-bottom: 3px; line-height: 1.5; }}
   .sim-notes strong {{ color: #2d3436; }}
+  .sim-chart-card {{
+    padding: 16px;
+  }}
+  .sim-chart-frame {{
+    position: relative; width: 100%; min-height: 220px; max-height: 320px; height: clamp(220px, 30vw, 300px);
+  }}
 
   @media (max-width: 700px) {{
-    [data-card-id="sim-chart"] {{ position: static; top: auto; }}
+    .sim-overview-stack {{ position: static; top: auto; }}
     .card {{ width: 100%; }}
     .sim-param-grid {{ grid-template-columns: 1fr; }}
+    .sim-summary-grid {{ grid-template-columns: 1fr 1fr; }}
+    .sim-chart-frame {{ min-height: 200px; height: 220px; }}
     .page-header {{ flex-direction: column; gap: 8px; align-items: flex-start; }}
     .nav-toolbar a {{ padding: 6px 10px; font-size: 0.78rem; }}
     h1 {{ font-size: 1.2rem; }}
     table {{ font-size: 0.8rem; }}
+  }}
+  @media (max-width: 520px) {{
+    .sim-summary-grid {{ grid-template-columns: 1fr; }}
+    .sim-prob-grid {{ grid-template-columns: 1fr; }}
   }}
 </style>
 </head>
@@ -3078,7 +3109,10 @@ def _build_simulator_html(data: dict, skip_update: bool = False) -> str:
     {_nav_html("/simulator")}
   </div>
   <div class="grid">
-    {chart_html}
+    <div class="sim-overview-stack full">
+      {chart_html}
+      {summary_html}
+    </div>
     <div class="card full" id="sim-params" data-card-id="sim-params">
       <div class="card-header">
         <h2>パラメータ設定</h2>
@@ -3095,7 +3129,6 @@ def _build_simulator_html(data: dict, skip_update: bool = False) -> str:
       </div>
     </div>
     {life_events_html}
-    {summary_html}
     {projection_table_html}
   </div>
 </div>

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -3041,7 +3041,7 @@ def _build_simulator_html(data: dict, skip_update: bool = False) -> str:
   .sim-chart-card .card-header {{
     margin-bottom: 10px;
   }}
-  .sim-summary-grid {{ display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; margin-bottom: 12px; }}
+  .sim-summary-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 10px; margin-bottom: 12px; }}
   .sim-summary-item {{
     text-align: left; padding: 10px 12px; background: rgba(248,249,250,0.92); border-radius: 10px;
     border: 1px solid #eef2f7;

--- a/tests/test_build_static.py
+++ b/tests/test_build_static.py
@@ -60,6 +60,48 @@ class TestBuildOutput:
         assert sentinel.read_text(encoding="utf-8") == "keep"
 
 
+class TestLiveModeEmptyData:
+    """live モードでデータ不足時は明示的にエラーになる。"""
+
+    def test_live_mode_raises_when_dashboard_empty(self, tmp_path):
+        """ダッシュボードデータ未取得時は RuntimeError。"""
+        empty_db = tmp_path / "empty.db"
+        # init_db でテーブルだけ作って中身は空にする
+        from src.db.schema import init_db
+
+        init_db(str(empty_db)).close()
+
+        with pytest.raises(RuntimeError, match="ダッシュボード用データがありません"):
+            build(output_dir=tmp_path / "out", mode="live", db_path=str(empty_db))
+
+    def test_live_mode_raises_when_cf_empty(self, tmp_path, monkeypatch):
+        """家計簿データ未取得時は RuntimeError。"""
+        import scripts.build_static as build_mod
+
+        # ダッシュボード/dates だけ偽の中身を返してパスさせ、CF で詰まることを確認
+        monkeypatch.setattr(build_mod, "_get_data", lambda db_path: {"date": "2026-01-01"})
+        monkeypatch.setattr(build_mod, "_get_dates", lambda db_path: ["2026-01-01"])
+        monkeypatch.setattr(build_mod, "_build_html", lambda *a, **k: "<html></html>")
+        monkeypatch.setattr(build_mod, "_get_cf_data", lambda db_path: {})
+
+        with pytest.raises(RuntimeError, match="家計簿用データがありません"):
+            build(output_dir=tmp_path / "out", mode="live", db_path="dummy.db")
+
+    def test_live_mode_raises_when_plan_empty(self, tmp_path, monkeypatch):
+        """ライフプランデータ未取得時は RuntimeError。"""
+        import scripts.build_static as build_mod
+
+        monkeypatch.setattr(build_mod, "_get_data", lambda db_path: {"date": "2026-01-01"})
+        monkeypatch.setattr(build_mod, "_get_dates", lambda db_path: ["2026-01-01"])
+        monkeypatch.setattr(build_mod, "_build_html", lambda *a, **k: "<html></html>")
+        monkeypatch.setattr(build_mod, "_get_cf_data", lambda db_path: {"year_month": "2026-01"})
+        monkeypatch.setattr(build_mod, "_build_cf_html", lambda *a, **k: "<html></html>")
+        monkeypatch.setattr(build_mod, "_get_plan_data", lambda db_path: {})
+
+        with pytest.raises(RuntimeError, match="ライフプラン用データがありません"):
+            build(output_dir=tmp_path / "out", mode="live", db_path="dummy.db")
+
+
 class TestSimulatorPage:
     """シミュレーターページの検証。"""
 

--- a/tests/test_build_static.py
+++ b/tests/test_build_static.py
@@ -12,27 +12,19 @@ EXPECTED_FILES = {"index.html", "cf.html", "plan.html", "simulator.html", ".noje
 
 
 @pytest.fixture(scope="module")
-def docs_dir(tmp_path_factory):
-    """ビルドを1回だけ実行して docs/ を返す。"""
-    import scripts.build_static as mod
-
-    # 一時ディレクトリにビルド
-    tmp = tmp_path_factory.mktemp("docs")
-    original = mod.DOCS_DIR
-    mod.DOCS_DIR = tmp
-    try:
-        build()
-    finally:
-        mod.DOCS_DIR = original
+def output_dir(tmp_path_factory):
+    """ビルドを1回だけ実行して出力ディレクトリを返す。"""
+    tmp = tmp_path_factory.mktemp("dist")
+    build(output_dir=tmp, mode="demo")
     return tmp
 
 
 @pytest.fixture(scope="module")
-def html_files(docs_dir):
+def html_files(output_dir):
     """各 HTML ファイルの内容を dict で返す。"""
     result = {}
     for name in ["index.html", "cf.html", "plan.html", "simulator.html"]:
-        path = docs_dir / name
+        path = output_dir / name
         if path.exists():
             result[name] = path.read_text(encoding="utf-8")
     return result
@@ -41,9 +33,9 @@ def html_files(docs_dir):
 class TestBuildOutput:
     """ビルド結果のファイル構成テスト。"""
 
-    def test_all_files_generated(self, docs_dir):
+    def test_all_files_generated(self, output_dir):
         """4 HTML + .nojekyll の 5 ファイルが生成される。"""
-        names = {f.name for f in docs_dir.iterdir()}
+        names = {f.name for f in output_dir.iterdir()}
         assert names == EXPECTED_FILES
 
     def test_html_files_not_empty(self, html_files):

--- a/tests/test_build_static.py
+++ b/tests/test_build_static.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 import pytest
 
@@ -42,6 +43,21 @@ class TestBuildOutput:
         """全 HTML ファイルが空でない。"""
         for name, content in html_files.items():
             assert len(content) > 1000, f"{name} is too small"
+
+    def test_rejects_repo_root_output(self):
+        """リポジトリルートを出力先に指定しても削除しない。"""
+        with pytest.raises(ValueError, match="危険な出力先"):
+            build(output_dir=Path.cwd(), mode="demo")
+
+    def test_rejects_non_empty_custom_output(self, tmp_path):
+        """空でない任意ディレクトリを出力先に指定しても削除しない。"""
+        sentinel = tmp_path / "keep.txt"
+        sentinel.write_text("keep", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="空ではありません"):
+            build(output_dir=tmp_path, mode="demo")
+
+        assert sentinel.read_text(encoding="utf-8") == "keep"
 
 
 class TestSimulatorPage:

--- a/tests/test_daily.py
+++ b/tests/test_daily.py
@@ -1,0 +1,43 @@
+import subprocess
+
+import pytest
+
+from src import daily
+
+
+def test_deploy_cloudflare_pages_raises_when_wrangler_missing(monkeypatch, tmp_path):
+    def fake_run(cmd, check):
+        raise FileNotFoundError("wrangler")
+
+    monkeypatch.setattr(daily.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="wrangler"):
+        daily._deploy_cloudflare_pages(tmp_path / "dist")
+
+
+def test_deploy_cloudflare_pages_propagates_command_failure(monkeypatch, tmp_path):
+    def fake_run(cmd, check):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(daily.subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        daily._deploy_cloudflare_pages(tmp_path / "dist")
+
+
+def test_deploy_cloudflare_pages_passes_project_name(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(cmd, check):
+        calls.append((cmd, check))
+
+    monkeypatch.setattr(daily.subprocess, "run", fake_run)
+
+    daily._deploy_cloudflare_pages(tmp_path / "dist", "asset-dashboard")
+
+    assert calls == [
+        (
+            ["wrangler", "pages", "deploy", str(tmp_path / "dist"), "--project-name", "asset-dashboard"],
+            True,
+        )
+    ]


### PR DESCRIPTION
## 概要
- 静的HTMLビルドを dist/ 出力に統一（--output で変更可能）
- scripts/build_static.py に --mode demo/live と --db-path を追加
- src.daily に --build-static / --deploy / --deploy-project-name を追加
  - --deploy で wrangler pages deploy dist/ を実行
- GitHub Pages workflow を dist/ 配信に変更

## テスト
- ./.venv/bin/pytest tests/test_build_static.py tests/test_server_html.py -q

Closes #54