### PR TITLE
ワンコマンドインストールスクリプト (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@
 
 ## セットアップ
 
+### ワンコマンドインストール（推奨）
+
+```bash
+# Linux / macOS / WSL
+bash install.sh
+
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -File install.ps1
+```
+
+Python 3.11+ の確認 → uv インストール → 仮想環境作成 → 依存インストール → Playwright Chromium インストールを一括実行する。
+
+### 手動セットアップ
+
 ```bash
 # 仮想環境の作成と依存インストール
 uv venv .venv

--- a/install.ps1
+++ b/install.ps1
@@ -8,10 +8,10 @@ $VENV_DIR = ".venv"
 
 # --- ヘルパー関数 -----------------------------------------------------------
 
-function Write-Info  { Write-Host "[INFO]  $args" -ForegroundColor Cyan }
-function Write-Ok    { Write-Host "[OK]    $args" -ForegroundColor Green }
-function Write-Warn  { Write-Host "[WARN]  $args" -ForegroundColor Yellow }
-function Write-Err   { Write-Host "[ERROR] $args" -ForegroundColor Red; exit 1 }
+function Write-Info  { param([string]$Message) Write-Host "[INFO]  $Message" -ForegroundColor Cyan }
+function Write-Ok    { param([string]$Message) Write-Host "[OK]    $Message" -ForegroundColor Green }
+function Write-Warn  { param([string]$Message) Write-Host "[WARN]  $Message" -ForegroundColor Yellow }
+function Write-Err   { param([string]$Message) Write-Host "[ERROR] $Message" -ForegroundColor Red; exit 1 }
 
 # --- Python チェック ---------------------------------------------------------
 
@@ -73,7 +73,7 @@ if (Test-Path $VENV_DIR) {
     Write-Info "既存の仮想環境を検出 ($VENV_DIR)"
 } else {
     Write-Info "仮想環境を作成中..."
-    uv venv $VENV_DIR --python $pythonCmd
+    uv venv $VENV_DIR --python $pythonVer
 }
 Write-Ok "仮想環境: $VENV_DIR"
 
@@ -81,10 +81,7 @@ $venvPython = Join-Path $VENV_DIR "Scripts\python.exe"
 
 # --- 依存インストール -------------------------------------------------------
 
-Write-Info "依存パッケージをインストール中..."
-uv pip install -e . --python $venvPython
-
-Write-Info "開発用パッケージをインストール中..."
+Write-Info "依存パッケージをインストール中 (本体 + 開発ツール)..."
 uv pip install -e ".[dev]" --python $venvPython
 Write-Ok "依存インストール完了"
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,117 @@
+# MoneyForward ME 資産トラッカー — ワンコマンドインストール (Windows PowerShell)
+# Usage: powershell -ExecutionPolicy Bypass -File install.ps1
+
+$ErrorActionPreference = "Stop"
+
+$PYTHON_MIN = [version]"3.11"
+$VENV_DIR = ".venv"
+
+# --- ヘルパー関数 -----------------------------------------------------------
+
+function Write-Info  { Write-Host "[INFO]  $args" -ForegroundColor Cyan }
+function Write-Ok    { Write-Host "[OK]    $args" -ForegroundColor Green }
+function Write-Warn  { Write-Host "[WARN]  $args" -ForegroundColor Yellow }
+function Write-Err   { Write-Host "[ERROR] $args" -ForegroundColor Red; exit 1 }
+
+# --- Python チェック ---------------------------------------------------------
+
+Write-Info "Python $PYTHON_MIN 以上を検索中..."
+
+$pythonCmd = $null
+foreach ($cmd in @("python3", "python", "py")) {
+    try {
+        $ver = & $cmd -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
+        if ($ver -and [version]$ver -ge $PYTHON_MIN) {
+            $pythonCmd = $cmd
+            $pythonVer = $ver
+            break
+        }
+    } catch { }
+}
+
+if (-not $pythonCmd) {
+    Write-Err @"
+Python $PYTHON_MIN 以上が見つかりません。
+  インストール方法:
+    winget : winget install Python.Python.3.12
+    公式   : https://www.python.org/downloads/
+"@
+}
+Write-Ok "Python $pythonVer ($pythonCmd)"
+
+# --- uv チェック・インストール -----------------------------------------------
+
+$uvPath = Get-Command uv -ErrorAction SilentlyContinue
+if (-not $uvPath) {
+    $localUv = Join-Path $env:LOCALAPPDATA "uv\uv.exe"
+    if (Test-Path $localUv) {
+        $env:PATH = "$(Split-Path $localUv);$env:PATH"
+        $uvPath = Get-Command uv -ErrorAction SilentlyContinue
+    }
+}
+
+if ($uvPath) {
+    $uvVer = (uv --version 2>$null) | Select-Object -First 1
+    Write-Ok "uv $uvVer"
+} else {
+    Write-Info "uv をインストール中..."
+    irm https://astral.sh/uv/install.ps1 | iex
+    # インストーラーが PATH を設定するまで再検索
+    $localUv = Join-Path $env:LOCALAPPDATA "uv\uv.exe"
+    if (Test-Path $localUv) {
+        $env:PATH = "$(Split-Path $localUv);$env:PATH"
+    }
+    if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+        Write-Err "uv のインストールに失敗しました。手動でインストールしてください: https://docs.astral.sh/uv/"
+    }
+    Write-Ok "uv インストール完了"
+}
+
+# --- 仮想環境 ---------------------------------------------------------------
+
+if (Test-Path $VENV_DIR) {
+    Write-Info "既存の仮想環境を検出 ($VENV_DIR)"
+} else {
+    Write-Info "仮想環境を作成中..."
+    uv venv $VENV_DIR --python $pythonCmd
+}
+Write-Ok "仮想環境: $VENV_DIR"
+
+$venvPython = Join-Path $VENV_DIR "Scripts\python.exe"
+
+# --- 依存インストール -------------------------------------------------------
+
+Write-Info "依存パッケージをインストール中..."
+uv pip install -e . --python $venvPython
+
+Write-Info "開発用パッケージをインストール中..."
+uv pip install -e ".[dev]" --python $venvPython
+Write-Ok "依存インストール完了"
+
+# --- Playwright Chromium ----------------------------------------------------
+
+Write-Info "Playwright Chromium をインストール中..."
+& $venvPython -m playwright install chromium
+Write-Ok "Playwright Chromium インストール完了"
+
+# --- 完了 -------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "==========================================" -ForegroundColor Green
+Write-Ok "インストール完了!"
+Write-Host "==========================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "次のステップ:"
+Write-Host ""
+Write-Host "  1. 仮想環境を有効化:"
+Write-Host "     $VENV_DIR\Scripts\Activate.ps1"
+Write-Host ""
+Write-Host "  2. 初回ログイン (ブラウザが開きます):"
+Write-Host "     python -m src.scraper.login"
+Write-Host ""
+Write-Host "  3. ダッシュボード起動:"
+Write-Host "     python -m src.web.server"
+Write-Host ""
+Write-Host "  デモモードで試す場合:"
+Write-Host "     python -m src.web.server --demo"
+Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# MoneyForward ME 資産トラッカー — ワンコマンドインストール
+# Usage: bash install.sh
+
+PYTHON_MIN="3.11"
+VENV_DIR=".venv"
+
+# --- ヘルパー関数 -----------------------------------------------------------
+
+info()  { printf '\033[1;34m[INFO]\033[0m  %s\n' "$*"; }
+ok()    { printf '\033[1;32m[OK]\033[0m    %s\n' "$*"; }
+warn()  { printf '\033[1;33m[WARN]\033[0m  %s\n' "$*"; }
+error() { printf '\033[1;31m[ERROR]\033[0m %s\n' "$*"; exit 1; }
+
+# バージョン文字列を比較 (a >= b なら 0)
+ver_gte() {
+    printf '%s\n%s' "$1" "$2" | sort -V | head -n1 | grep -qx "$2"
+}
+
+# --- Python チェック ---------------------------------------------------------
+
+find_python() {
+    for cmd in python3 python; do
+        if command -v "$cmd" &>/dev/null; then
+            local ver
+            ver=$("$cmd" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null) || continue
+            if ver_gte "$ver" "$PYTHON_MIN"; then
+                PYTHON_CMD="$cmd"
+                PYTHON_VER="$ver"
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+info "Python $PYTHON_MIN 以上を検索中..."
+if ! find_python; then
+    error "Python $PYTHON_MIN 以上が見つかりません。
+  インストール方法:
+    Ubuntu/Debian : sudo apt install python3
+    macOS         : brew install python@3.12
+    その他        : https://www.python.org/downloads/"
+fi
+ok "Python $PYTHON_VER ($PYTHON_CMD)"
+
+# --- uv チェック・インストール -----------------------------------------------
+
+if ! command -v uv &>/dev/null && [ -f "$HOME/.local/bin/uv" ]; then
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+if command -v uv &>/dev/null; then
+    ok "uv $(uv --version 2>/dev/null | head -1)"
+else
+    info "uv をインストール中..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="$HOME/.local/bin:$PATH"
+    if ! command -v uv &>/dev/null; then
+        error "uv のインストールに失敗しました。手動でインストールしてください: https://docs.astral.sh/uv/"
+    fi
+    ok "uv インストール完了"
+fi
+
+# --- 仮想環境 ---------------------------------------------------------------
+
+if [ -d "$VENV_DIR" ]; then
+    info "既存の仮想環境を検出 ($VENV_DIR)"
+else
+    info "仮想環境を作成中..."
+    uv venv "$VENV_DIR" --python "$PYTHON_CMD"
+fi
+ok "仮想環境: $VENV_DIR"
+
+# --- 依存インストール -------------------------------------------------------
+
+info "依存パッケージをインストール中..."
+uv pip install -e . --python "$VENV_DIR/bin/python"
+
+info "開発用パッケージをインストール中..."
+uv pip install -e '.[dev]' --python "$VENV_DIR/bin/python"
+ok "依存インストール完了"
+
+# --- Playwright Chromium ----------------------------------------------------
+
+info "Playwright Chromium をインストール中..."
+"$VENV_DIR/bin/python" -m playwright install chromium
+ok "Playwright Chromium インストール完了"
+
+# Playwright のシステム依存チェック
+info "Chromium のシステム依存ライブラリを確認中..."
+if "$VENV_DIR/bin/python" -m playwright install-deps chromium 2>/dev/null; then
+    ok "システム依存ライブラリ OK"
+else
+    warn "システム依存ライブラリのインストールに失敗しました。
+  必要に応じて以下を手動実行してください:
+    sudo $VENV_DIR/bin/python -m playwright install-deps chromium"
+fi
+
+# --- 完了 -------------------------------------------------------------------
+
+echo ""
+echo "=========================================="
+ok "インストール完了!"
+echo "=========================================="
+echo ""
+echo "次のステップ:"
+echo ""
+echo "  1. 仮想環境を有効化:"
+echo "     source $VENV_DIR/bin/activate"
+echo ""
+echo "  2. 初回ログイン (ブラウザが開きます):"
+echo "     python -m src.scraper.login"
+echo ""
+echo "  3. ダッシュボード起動:"
+echo "     python -m src.web.server"
+echo ""
+echo "  デモモードで試す場合:"
+echo "     python -m src.web.server --demo"
+echo ""

--- a/install.sh
+++ b/install.sh
@@ -15,8 +15,13 @@ warn()  { printf '\033[1;33m[WARN]\033[0m  %s\n' "$*"; }
 error() { printf '\033[1;31m[ERROR]\033[0m %s\n' "$*"; exit 1; }
 
 # バージョン文字列を比較 (a >= b なら 0)
+# macOS の BSD sort は -V 未対応のため数値比較で実装
 ver_gte() {
-    printf '%s\n%s' "$1" "$2" | sort -V | head -n1 | grep -qx "$2"
+    local IFS=.
+    local -a a=($1) b=($2)
+    (( ${a[0]:-0} > ${b[0]:-0} )) && return 0
+    (( ${a[0]:-0} < ${b[0]:-0} )) && return 1
+    (( ${a[1]:-0} >= ${b[1]:-0} ))
 }
 
 # --- Python チェック ---------------------------------------------------------
@@ -27,7 +32,7 @@ find_python() {
             local ver
             ver=$("$cmd" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null) || continue
             if ver_gte "$ver" "$PYTHON_MIN"; then
-                PYTHON_CMD="$cmd"
+                PYTHON_CMD="$(command -v "$cmd")"
                 PYTHON_VER="$ver"
                 return 0
             fi
@@ -76,10 +81,7 @@ ok "仮想環境: $VENV_DIR"
 
 # --- 依存インストール -------------------------------------------------------
 
-info "依存パッケージをインストール中..."
-uv pip install -e . --python "$VENV_DIR/bin/python"
-
-info "開発用パッケージをインストール中..."
+info "依存パッケージをインストール中 (本体 + 開発ツール)..."
 uv pip install -e '.[dev]' --python "$VENV_DIR/bin/python"
 ok "依存インストール完了"
 


### PR DESCRIPTION
## Summary
- `install.sh` (Linux/macOS/WSL) と `install.ps1` (Windows) を新規作成
- Python 3.11+ チェック → uv 自動インストール → venv 作成 → 依存インストール → Playwright Chromium を一括実行
- README にワンコマンドセットアップ手順を追記

## Test plan
- [x] `bash -n install.sh` 構文チェック通過
- [x] 既存テスト 254 件すべて通過
- [ ] クリーンな Linux 環境で `install.sh` を実行して正常完了するか
- [ ] クリーンな Windows 環境で `install.ps1` を実行して正常完了するか
- [ ] Python 未インストール時のエラーメッセージが分かりやすいか

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)