### PR TITLE
[codex] 配当データ取得のフォールバックを改善

### DIFF
--- a/src/data/dividend_fetcher.py
+++ b/src/data/dividend_fetcher.py
@@ -12,11 +12,66 @@ import re
 import time
 import urllib.request
 from datetime import date
+from html import unescape
 from pathlib import Path
 
 _YAHOO_URL = "https://finance.yahoo.co.jp/quote/{code}.T"
-_DPS_RE = re.compile(r'"dps":"(\d+(?:\.\d+)?)","dpsDate":"([^"]+)"')
+_DPS_RE = re.compile(r'"dps"\s*:\s*(?:"(?P<dps_str>[\d,]+(?:\.\d+)?)"|(?P<dps_num>[\d,]+(?:\.\d+)?))')
+_DPS_DATE_RE = re.compile(r'"dpsDate"\s*:\s*"(?P<date>[^"]+)"')
+_DPS_TEXT_RE = re.compile(r"([\d,]+(?:\.\d+)?)\s*円\s*\(([^)]+)\)")
 _JSON_PATH = Path(__file__).resolve().parent.parent.parent / "data" / "dividends.json"
+
+
+def _parse_number(value: str) -> float:
+    return float(value.replace(",", ""))
+
+
+def _parse_dividend_html(html: str) -> tuple[float | None, str | None]:
+    """Yahoo Finance Japan の銘柄ページ HTML から年間予想配当を抽出する。"""
+    m = _DPS_RE.search(html)
+    if m:
+        date_match = _DPS_DATE_RE.search(html)
+        return _parse_number(m.group("dps_str") or m.group("dps_num")), date_match.group("date") if date_match else None
+
+    text = unescape(re.sub(r"<[^>]+>", "\n", html))
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    for i, line in enumerate(lines):
+        if "1株配当" not in line:
+            continue
+        window = "\n".join(lines[i : i + 12])
+        if "会社予想" not in window and "予想" not in window:
+            continue
+        text_match = _DPS_TEXT_RE.search(window)
+        if text_match:
+            return _parse_number(text_match.group(1)), text_match.group(2).strip()
+    return None, None
+
+
+def _fallback_dividend_entry(code: str, fetched: str) -> dict | None:
+    """自動取得できない場合に、銘柄マスタの値で安全に補完する。"""
+    from src.data.stock_master import STOCK_MASTER, US_STOCK_MASTER, is_us_stock
+
+    master = US_STOCK_MASTER.get(code) if is_us_stock(code) else STOCK_MASTER.get(code)
+    if not master:
+        return None
+    dps = float(master.get("dividend") or 0)
+    if dps <= 0:
+        return None
+    return {"dps": dps, "date": None, "fetched": fetched, "source": "stock_master_fallback"}
+
+
+def _keep_or_fallback(data: dict, code: str, fetched: str) -> str:
+    existing = data.get(code, {})
+    existing_dps = float(existing.get("dps") or 0)
+    fallback = _fallback_dividend_entry(code, fetched)
+    if existing_dps > 0 and existing.get("source") != "stock_master_fallback":
+        return f"{existing_dps}円（dps未検出: 既存値を保持）"
+    if fallback:
+        data[code] = fallback
+        return f"{fallback['dps']}円（dps未検出: 銘柄マスタ値で補完）"
+
+    data[code] = {"dps": 0, "date": None, "fetched": fetched, "source": "not_found"}
+    return "0円（dps未検出）"
 
 
 def fetch_dividend(code: str) -> tuple[float | None, str | None]:
@@ -29,18 +84,49 @@ def fetch_dividend(code: str) -> tuple[float | None, str | None]:
     req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
     with urllib.request.urlopen(req, timeout=10) as resp:
         html = resp.read().decode("utf-8")
-    m = _DPS_RE.search(html)
-    if m is None:
-        return None, None
-    return float(m.group(1)), m.group(2)
+    return _parse_dividend_html(html)
+
+
+def _get_portfolio_stock_codes() -> list[str]:
+    """DB のポートフォリオから株式銘柄コードを取得する。"""
+    from src.db.schema import DEFAULT_DB_PATH
+
+    if not DEFAULT_DB_PATH.exists():
+        return []
+    import sqlite3
+
+    conn = sqlite3.connect(str(DEFAULT_DB_PATH))
+    try:
+        rows = conn.execute(
+            """SELECT DISTINCT symbol_or_code FROM snapshot_holdings
+               WHERE asset_class = '株式（現物）'
+                 AND symbol_or_code != ''
+                 AND date = (SELECT MAX(date) FROM snapshots)"""
+        ).fetchall()
+        return [r[0] for r in rows]
+    except Exception:
+        return []
+    finally:
+        conn.close()
 
 
 def update_all_dividends(codes: list[str] | None = None) -> dict:
-    """全銘柄の配当を取得し dividends.json に保存する。"""
+    """全銘柄の配当を取得し dividends.json に保存する。
+
+    codes 未指定時は STOCK_MASTER + ポートフォリオ（DB）の和集合を処理する。
+    """
     if codes is None:
         from src.data.stock_master import get_all_codes
 
-        codes = get_all_codes()
+        master_codes = get_all_codes()
+        portfolio_codes = _get_portfolio_stock_codes()
+        # マスタ優先、ポートフォリオにしかない銘柄を末尾に追加
+        seen = set(master_codes)
+        codes = list(master_codes)
+        for c in portfolio_codes:
+            if c not in seen:
+                codes.append(c)
+                seen.add(c)
 
     # 既存データを読み込む（マージ用）
     data: dict = {}
@@ -57,10 +143,9 @@ def update_all_dividends(codes: list[str] | None = None) -> dict:
                 data[code] = {"dps": dps, "date": dps_date, "fetched": today}
                 print(f"{dps}円 ({dps_date})")
             else:
-                data[code] = {"dps": 0, "date": None, "fetched": today}
-                print("0円（ETF等: dps未検出）")
+                print(_keep_or_fallback(data, code, today))
         except Exception as e:
-            print(f"エラー: {e}")
+            print(f"エラー: {e} / {_keep_or_fallback(data, code, today)}")
         if i < len(codes) - 1:
             time.sleep(1)
 

--- a/src/data/stock_master.py
+++ b/src/data/stock_master.py
@@ -30,8 +30,9 @@ STOCK_MASTER: dict[str, dict] = {
     "5401": {"name": "日本製鉄", "sector": "鉄鋼", "dividend": 160},
     "9432": {"name": "NTT", "sector": "情報・通信業", "dividend": 5.2},
     "8200": {"name": "リンガーハット", "sector": "小売業", "dividend": 15},
-    "1478": {"name": "iS高配当ETF", "sector": "ETF", "dividend": 500},
-    "4755": {"name": "楽天グループ", "sector": "サービス業", "dividend": 4.5},
+    "8593": {"name": "三菱HCキャピタル", "sector": "その他金融業", "dividend": 40},
+    "1478": {"name": "iS高配当ETF", "sector": "ETF", "dividend": 110.0},
+    "4755": {"name": "楽天グループ", "sector": "サービス業", "dividend": 0.0},
 }
 
 # 米国株マスター（ティッカーシンボル → 業種・配当）
@@ -181,7 +182,18 @@ def get_dividend(code: str) -> float:
     """
     divs = _load_dividends()
     if code in divs:
-        return divs[code]["dps"]
+        entry = divs[code]
+        dps = float(entry.get("dps") or 0)
+        if entry.get("source") == "stock_master_fallback":
+            dps = 0
+            if is_us_stock(code):
+                us_info = US_STOCK_MASTER.get(code)
+                dps = float(us_info.get("dividend") or 0) if us_info else 0
+            else:
+                info = STOCK_MASTER.get(code)
+                dps = float(info.get("dividend") or 0) if info else 0
+        if dps > 0 or entry.get("date") is not None:
+            return dps
     # 米国株
     if is_us_stock(code):
         us_info = US_STOCK_MASTER.get(code)

--- a/tests/test_dividend_data.py
+++ b/tests/test_dividend_data.py
@@ -1,0 +1,82 @@
+import json
+
+from src.data import dividend_fetcher, stock_master
+
+
+def test_parse_dividend_html_current_yahoo_text_format():
+    html = """
+    <html><body>
+      <a><span>1株配当</span><span>（会社予想）</span></a>
+      <span>用語</span>
+      <span>140.00</span><span>円</span><span>(<!-- -->2026/03<!-- -->)</span>
+      <span>PER （会社予想）</span>
+    </body></html>
+    """
+
+    assert dividend_fetcher._parse_dividend_html(html) == (140.0, "2026/03")
+
+
+def test_parse_dividend_html_json_format():
+    html = '{"dps": "125.5", "dpsDate": "2026/03"}'
+
+    assert dividend_fetcher._parse_dividend_html(html) == (125.5, "2026/03")
+
+
+def test_get_dividend_falls_back_when_cached_zero_is_missing(monkeypatch, tmp_path):
+    path = tmp_path / "dividends.json"
+    path.write_text(json.dumps({"8053": {"dps": 0, "date": None, "fetched": "2026-04-22"}}), encoding="utf-8")
+    monkeypatch.setattr(stock_master, "_DIVIDENDS_JSON", path)
+    monkeypatch.setattr(stock_master, "_dividend_cache", None)
+
+    assert stock_master.get_dividend("8053") == 125
+
+
+def test_get_dividend_keeps_explicit_zero_with_date(monkeypatch, tmp_path):
+    path = tmp_path / "dividends.json"
+    path.write_text(json.dumps({"8053": {"dps": 0, "date": "2026/03", "fetched": "2026-04-22"}}), encoding="utf-8")
+    monkeypatch.setattr(stock_master, "_DIVIDENDS_JSON", path)
+    monkeypatch.setattr(stock_master, "_dividend_cache", None)
+
+    assert stock_master.get_dividend("8053") == 0
+
+
+def test_get_dividend_recomputes_stock_master_fallback_from_current_master(monkeypatch, tmp_path):
+    path = tmp_path / "dividends.json"
+    path.write_text(
+        json.dumps({"4755": {"dps": 4.5, "date": None, "fetched": "2026-04-22", "source": "stock_master_fallback"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(stock_master, "_DIVIDENDS_JSON", path)
+    monkeypatch.setattr(stock_master, "_dividend_cache", None)
+
+    assert stock_master.get_dividend("4755") == 0
+
+
+def test_get_dividend_recomputes_etf_stock_master_fallback_from_current_master(monkeypatch, tmp_path):
+    path = tmp_path / "dividends.json"
+    path.write_text(
+        json.dumps({"1478": {"dps": 500.0, "date": None, "fetched": "2026-04-22", "source": "stock_master_fallback"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(stock_master, "_DIVIDENDS_JSON", path)
+    monkeypatch.setattr(stock_master, "_dividend_cache", None)
+
+    assert stock_master.get_dividend("1478") == 110.0
+
+
+def test_keep_or_fallback_does_not_keep_stale_stock_master_fallback():
+    data = {"4755": {"dps": 4.5, "date": None, "fetched": "2026-04-22", "source": "stock_master_fallback"}}
+
+    message = dividend_fetcher._keep_or_fallback(data, "4755", "2026-04-22")
+
+    assert message == "0円（dps未検出）"
+    assert data["4755"] == {"dps": 0, "date": None, "fetched": "2026-04-22", "source": "not_found"}
+
+
+def test_keep_or_fallback_keeps_existing_real_fetch_before_master_fallback():
+    data = {"8053": {"dps": 140.0, "date": "2026/03", "fetched": "2026-04-22"}}
+
+    message = dividend_fetcher._keep_or_fallback(data, "8053", "2026-04-23")
+
+    assert message == "140.0円（dps未検出: 既存値を保持）"
+    assert data["8053"] == {"dps": 140.0, "date": "2026/03", "fetched": "2026-04-22"}


### PR DESCRIPTION
## Summary
- Yahoo Finance Japan の配当HTML抽出を JSON 形式と現在のテキスト形式の両方に対応
- 配当取得に失敗した場合、既存の実取得値や銘柄マスタ値で補完し、古い stock_master_fallback を再評価するよう修正
- DB内の最新ポートフォリオ銘柄も配当更新対象に含め、配当取得まわりの回帰テストを追加

## Why
Yahoo Finance 側のHTML形式変化や一時的な取得失敗で `dividends.json` に 0 円が保存されると、配当見込みの表示・AIコメントに誤った値が出る可能性がありました。

## Validation
- `.venv/bin/pytest tests/test_dividend_data.py tests/test_ai_comment.py tests/test_server_html.py`