### PR TITLE
配当取得を Yahoo HTML 新形式に対応、取得不可は明示的にエラー表示

### DIFF
--- a/src/analysis/ai_comment.py
+++ b/src/analysis/ai_comment.py
@@ -117,8 +117,9 @@ def _build_dashboard_prompt(db_path: str, date: str) -> str:
             sector_totals[sector] = sector_totals.get(sector, 0) + value
             if quantity:
                 dps = get_dividend(code)
-                dps_jpy = dps * usd_jpy if is_us_stock(code) else dps
-                total_dividend += dps_jpy * quantity
+                if dps is not None:
+                    dps_jpy = dps * usd_jpy if is_us_stock(code) else dps
+                    total_dividend += dps_jpy * quantity
 
     sector_sorted = sorted(sector_totals.items(), key=lambda x: x[1], reverse=True)[:5]
     sector_lines = [f"  {sec}: {amt:,.0f}円" for sec, amt in sector_sorted]

--- a/src/data/dividend_fetcher.py
+++ b/src/data/dividend_fetcher.py
@@ -15,7 +15,14 @@ from datetime import date
 from pathlib import Path
 
 _YAHOO_URL = "https://finance.yahoo.co.jp/quote/{code}.T"
-_DPS_RE = re.compile(r'"dps":"(\d+(?:\.\d+)?)","dpsDate":"([^"]+)"')
+# 旧形式: "dps":"145","dpsDate":"2027/03"
+_DPS_RE_LEGACY = re.compile(r'"dps":"(\d+(?:\.\d+)?)","dpsDate":"([^"]+)"')
+# 新形式: \"dps\":{\"name\":\"1株配当\",...,\"value\":\"84.00\",\"updateDate\":\"2027/03\",...}
+# JSON が HTML 内に文字列としてエスケープ埋め込みされている
+_DPS_RE_NEW = re.compile(
+    r'\\"dps\\":\{[^{}]*?\\"value\\":\\"(\d+(?:\.\d+)?)\\"'
+    r'(?:[^{}]*?\\"updateDate\\":\\"([^"\\]+)\\")?'
+)
 _JSON_PATH = Path(__file__).resolve().parent.parent.parent / "data" / "dividends.json"
 
 
@@ -29,7 +36,10 @@ def fetch_dividend(code: str) -> tuple[float | None, str | None]:
     req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
     with urllib.request.urlopen(req, timeout=10) as resp:
         html = resp.read().decode("utf-8")
-    m = _DPS_RE.search(html)
+    # 新形式を優先、なければ旧形式にフォールバック
+    m = _DPS_RE_NEW.search(html)
+    if m is None:
+        m = _DPS_RE_LEGACY.search(html)
     if m is None:
         return None, None
     return float(m.group(1)), m.group(2)
@@ -57,8 +67,10 @@ def update_all_dividends(codes: list[str] | None = None) -> dict:
                 data[code] = {"dps": dps, "date": dps_date, "fetched": today}
                 print(f"{dps}円 ({dps_date})")
             else:
-                data[code] = {"dps": 0, "date": None, "fetched": today}
-                print("0円（ETF等: dps未検出）")
+                # ETF や無配確定銘柄など dps を抽出できなかったケースは null で保存し、
+                # UI 側で「取得エラー」として扱う（ハードコード値にはフォールバックしない）
+                data[code] = {"dps": None, "date": None, "fetched": today}
+                print("取得不可（dps 未検出）")
         except Exception as e:
             print(f"エラー: {e}")
         if i < len(codes) - 1:

--- a/src/data/stock_master.py
+++ b/src/data/stock_master.py
@@ -1,7 +1,8 @@
-"""銘柄マスタ: 業種分類・配当情報。
+"""銘柄マスタ: 業種分類。
 
-配当は data/dividends.json（自動取得）を優先し、
-なければハードコード値にフォールバックする。
+配当は data/dividends.json（自動取得）のみを参照する。
+取得できない銘柄は None を返し、UI 側で「取得エラー」表示する。
+（ハードコードフォールバックは古くなる/誤情報になりやすいため廃止）
 
 業種は data/sectors.json（自動取得）→ STOCK_MASTER の順でフォールバックする。
 """
@@ -18,47 +19,48 @@ _SECTORS_JSON = Path(__file__).resolve().parent.parent.parent / "data" / "sector
 _dividend_cache: dict | None = None
 _sector_cache: dict | None = None
 
+# 業種分類のみ保持。配当はハードコードせず dividends.json（自動取得）のみを参照。
 STOCK_MASTER: dict[str, dict] = {
-    "8053": {"name": "住友商事", "sector": "卸売業", "dividend": 125},
-    "8766": {"name": "東京海上HD", "sector": "保険業", "dividend": 159},
-    "4502": {"name": "武田薬品", "sector": "医薬品", "dividend": 196},
-    "8591": {"name": "オリックス", "sector": "その他金融業", "dividend": 98.6},
-    "9433": {"name": "KDDI", "sector": "情報・通信業", "dividend": 145},
-    "6918": {"name": "アバールデータ", "sector": "電気機器", "dividend": 80},
-    "1928": {"name": "積水ハウス", "sector": "建設業", "dividend": 129},
-    "7762": {"name": "シチズン時計", "sector": "精密機器", "dividend": 46},
-    "5401": {"name": "日本製鉄", "sector": "鉄鋼", "dividend": 160},
-    "9432": {"name": "NTT", "sector": "情報・通信業", "dividend": 5.2},
-    "8200": {"name": "リンガーハット", "sector": "小売業", "dividend": 15},
-    "1478": {"name": "iS高配当ETF", "sector": "ETF", "dividend": 500},
-    "4755": {"name": "楽天グループ", "sector": "サービス業", "dividend": 4.5},
+    "8053": {"name": "住友商事", "sector": "卸売業"},
+    "8766": {"name": "東京海上HD", "sector": "保険業"},
+    "4502": {"name": "武田薬品", "sector": "医薬品"},
+    "8591": {"name": "オリックス", "sector": "その他金融業"},
+    "9433": {"name": "KDDI", "sector": "情報・通信業"},
+    "6918": {"name": "アバールデータ", "sector": "電気機器"},
+    "1928": {"name": "積水ハウス", "sector": "建設業"},
+    "7762": {"name": "シチズン時計", "sector": "精密機器"},
+    "5401": {"name": "日本製鉄", "sector": "鉄鋼"},
+    "9432": {"name": "NTT", "sector": "情報・通信業"},
+    "8200": {"name": "リンガーハット", "sector": "小売業"},
+    "1478": {"name": "iS高配当ETF", "sector": "ETF"},
+    "4755": {"name": "楽天グループ", "sector": "サービス業"},
 }
 
-# 米国株マスター（ティッカーシンボル → 業種・配当）
+# 米国株マスター（ティッカーシンボル → 業種）
 US_STOCK_MASTER: dict[str, dict] = {
-    "AAPL": {"name": "Apple", "sector": "テクノロジー", "dividend": 1.00},
-    "MSFT": {"name": "Microsoft", "sector": "テクノロジー", "dividend": 3.32},
-    "GOOGL": {"name": "Alphabet", "sector": "テクノロジー", "dividend": 0.80},
-    "GOOG": {"name": "Alphabet C", "sector": "テクノロジー", "dividend": 0.80},
-    "AMZN": {"name": "Amazon", "sector": "消費財", "dividend": 0.0},
-    "NVDA": {"name": "NVIDIA", "sector": "テクノロジー", "dividend": 0.04},
-    "META": {"name": "Meta Platforms", "sector": "テクノロジー", "dividend": 2.00},
-    "TSLA": {"name": "Tesla", "sector": "自動車", "dividend": 0.0},
-    "JPM": {"name": "JPMorgan Chase", "sector": "金融", "dividend": 5.00},
-    "V": {"name": "Visa", "sector": "金融", "dividend": 2.36},
-    "JNJ": {"name": "Johnson & Johnson", "sector": "ヘルスケア", "dividend": 4.96},
-    "PG": {"name": "Procter & Gamble", "sector": "消費財", "dividend": 4.03},
-    "KO": {"name": "Coca-Cola", "sector": "消費財", "dividend": 1.94},
-    "PEP": {"name": "PepsiCo", "sector": "消費財", "dividend": 5.42},
-    "HD": {"name": "Home Depot", "sector": "小売", "dividend": 9.00},
-    "VZ": {"name": "Verizon", "sector": "通信", "dividend": 2.71},
-    "T": {"name": "AT&T", "sector": "通信", "dividend": 1.11},
-    "XOM": {"name": "Exxon Mobil", "sector": "エネルギー", "dividend": 3.96},
-    "VTI": {"name": "Vanguard Total Stock ETF", "sector": "米国ETF", "dividend": 3.44},
-    "VOO": {"name": "Vanguard S&P 500 ETF", "sector": "米国ETF", "dividend": 6.76},
-    "VYM": {"name": "Vanguard High Div ETF", "sector": "米国ETF", "dividend": 3.21},
-    "SPYD": {"name": "SPDR S&P 500 High Div ETF", "sector": "米国ETF", "dividend": 1.98},
-    "QQQ": {"name": "Invesco QQQ Trust", "sector": "米国ETF", "dividend": 2.86},
+    "AAPL": {"name": "Apple", "sector": "テクノロジー"},
+    "MSFT": {"name": "Microsoft", "sector": "テクノロジー"},
+    "GOOGL": {"name": "Alphabet", "sector": "テクノロジー"},
+    "GOOG": {"name": "Alphabet C", "sector": "テクノロジー"},
+    "AMZN": {"name": "Amazon", "sector": "消費財"},
+    "NVDA": {"name": "NVIDIA", "sector": "テクノロジー"},
+    "META": {"name": "Meta Platforms", "sector": "テクノロジー"},
+    "TSLA": {"name": "Tesla", "sector": "自動車"},
+    "JPM": {"name": "JPMorgan Chase", "sector": "金融"},
+    "V": {"name": "Visa", "sector": "金融"},
+    "JNJ": {"name": "Johnson & Johnson", "sector": "ヘルスケア"},
+    "PG": {"name": "Procter & Gamble", "sector": "消費財"},
+    "KO": {"name": "Coca-Cola", "sector": "消費財"},
+    "PEP": {"name": "PepsiCo", "sector": "消費財"},
+    "HD": {"name": "Home Depot", "sector": "小売"},
+    "VZ": {"name": "Verizon", "sector": "通信"},
+    "T": {"name": "AT&T", "sector": "通信"},
+    "XOM": {"name": "Exxon Mobil", "sector": "エネルギー"},
+    "VTI": {"name": "Vanguard Total Stock ETF", "sector": "米国ETF"},
+    "VOO": {"name": "Vanguard S&P 500 ETF", "sector": "米国ETF"},
+    "VYM": {"name": "Vanguard High Div ETF", "sector": "米国ETF"},
+    "SPYD": {"name": "SPDR S&P 500 High Div ETF", "sector": "米国ETF"},
+    "QQQ": {"name": "Invesco QQQ Trust", "sector": "米国ETF"},
 }
 
 _YAHOO_URL = "https://finance.yahoo.co.jp/quote/{code}.T"
@@ -173,22 +175,24 @@ def _load_dividends() -> dict:
     return _dividend_cache
 
 
-def get_dividend(code: str) -> float:
+def get_dividend(code: str) -> float | None:
     """銘柄コードから年間予想配当を返す。
 
     日本株: 円/株、米国株: USD/株。
-    dividends.json を優先し、なければハードコード値にフォールバック。
+    dividends.json に登録された数値のみを返し、未取得・取得失敗・null の場合は
+    None を返す（UI 側で「取得エラー」表示するため）。
     """
     divs = _load_dividends()
-    if code in divs:
-        return divs[code]["dps"]
-    # 米国株
-    if is_us_stock(code):
-        us_info = US_STOCK_MASTER.get(code)
-        return us_info["dividend"] if us_info else 0.0
-    # 日本株
-    info = STOCK_MASTER.get(code)
-    return info["dividend"] if info else 0.0
+    cached = divs.get(code)
+    if cached is None:
+        return None
+    dps = cached.get("dps")
+    if dps is None:
+        return None
+    try:
+        return float(dps)
+    except (TypeError, ValueError):
+        return None
 
 
 def get_all_codes() -> list[str]:

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -427,17 +427,32 @@ def _get_data(db_path: str, date: str | None = None) -> dict:
     sector_totals = dict(sorted(sector_totals.items(), key=lambda x: x[1], reverse=True))
 
     # 配当予測（株式のみ）
+    # get_dividend は取得できない銘柄に対して None を返す。集計には含めず、
+    # 一覧の「配当/株」「年間配当」「利回り」列に「取得エラー」を表示する。
     usd_jpy = 150.0  # 米国株配当の円換算レート
     dividends: list[dict] = []
     total_dividend = 0.0
+    dividend_error_count = 0
     for h in holdings:
         if h["asset_class"] == "株式（現物）" and h["code"] and h["quantity"]:
             dps = get_dividend(h["code"])
+            if dps is None:
+                dividend_error_count += 1
+                dividends.append(
+                    {
+                        "code": h["code"],
+                        "name": h["name"],
+                        "quantity": h["quantity"],
+                        "dps": None,
+                        "annual": None,
+                        "current_yield": None,
+                        "acq_yield": None,
+                        "error": True,
+                    }
+                )
+                continue
             # 米国株の配当は USD → JPY に変換
-            if is_us_stock(h["code"]):
-                dps_jpy = dps * usd_jpy
-            else:
-                dps_jpy = dps
+            dps_jpy = dps * usd_jpy if is_us_stock(h["code"]) else dps
             annual = dps_jpy * h["quantity"]
             total_dividend += annual
             if dps > 0:
@@ -454,13 +469,17 @@ def _get_data(db_path: str, date: str | None = None) -> dict:
                         "annual": annual,
                         "current_yield": current_yield,
                         "acq_yield": acq_yield,
+                        "error": False,
                     }
                 )
-    dividends.sort(key=lambda x: x["annual"], reverse=True)
+    # 取得エラー銘柄は末尾に並べる
+    dividends.sort(key=lambda x: (x.get("error", False), -(x["annual"] or 0)))
 
     # 配当利回り別内訳（低配当0-2% / 中配当2-4% / 高配当4%超）
     yield_breakdown: dict[str, float] = {"低配当 (0-2%)": 0, "中配当 (2-4%)": 0, "高配当 (4%超)": 0}
     for d in dividends:
+        if d.get("error"):
+            continue
         cy = d.get("current_yield")
         if cy is None:
             continue
@@ -473,18 +492,18 @@ def _get_data(db_path: str, date: str | None = None) -> dict:
         else:
             yield_breakdown["高配当 (4%超)"] += stock_value
 
-    # 業種別配当内訳
+    # 業種別配当内訳（取得エラー銘柄は配当合算から除外）
     sector_dividends: dict[str, dict] = {}
     for h in holdings:
         if h["asset_class"] == "株式（現物）" and h["code"] and h["quantity"]:
             sector = get_sector(h["code"])
             dps = get_dividend(h["code"])
-            dps_jpy = dps * usd_jpy if is_us_stock(h["code"]) else dps
-            annual = dps_jpy * h["quantity"]
             if sector not in sector_dividends:
                 sector_dividends[sector] = {"value": 0, "dividend": 0}
             sector_dividends[sector]["value"] += h["value"]
-            sector_dividends[sector]["dividend"] += annual
+            if dps is not None:
+                dps_jpy = dps * usd_jpy if is_us_stock(h["code"]) else dps
+                sector_dividends[sector]["dividend"] += dps_jpy * h["quantity"]
     # 加重利回りを計算
     for sec_data in sector_dividends.values():
         sec_data["yield"] = (sec_data["dividend"] / sec_data["value"] * 100) if sec_data["value"] > 0 else 0
@@ -515,6 +534,7 @@ def _get_data(db_path: str, date: str | None = None) -> dict:
         "sector_totals": sector_totals,
         "dividends": dividends,
         "total_dividend": total_dividend,
+        "dividend_error_count": dividend_error_count,
         "yield_breakdown": yield_breakdown,
         "sector_dividends": sector_dividends,
         "volatility": vol,
@@ -531,7 +551,9 @@ def _avg_yield_html(dividends: list[dict]) -> str:
     total_value = 0.0
     total_div = 0.0
     for d in dividends:
-        if d.get("current_yield") is not None and d["annual"] > 0:
+        if d.get("error"):
+            continue
+        if d.get("current_yield") is not None and d["annual"] and d["annual"] > 0:
             # 銘柄の評価額 = dps / (current_yield/100) * quantity
             # 簡易的に annual / (current_yield/100) で株式部分の評価額を逆算
             stock_value = d["annual"] / (d["current_yield"] / 100)
@@ -636,6 +658,7 @@ def _build_html(
     sector_totals = data.get("sector_totals", {})
     dividends = data.get("dividends", [])
     total_dividend = data.get("total_dividend", 0)
+    dividend_error_count = data.get("dividend_error_count", 0)
     yield_breakdown = data.get("yield_breakdown", {})
     sector_dividends = data.get("sector_dividends", {})
     vol = data.get("volatility")
@@ -813,6 +836,12 @@ def _build_html(
     # 配当予測 rows
     div_rows = ""
     for d in dividends:
+        if d.get("error"):
+            err = '<span class="div-error">取得エラー</span>'
+            div_rows += f'<tr class="div-err-row"><td><span class="code">{_h(d["code"])}</span> {_h(d["name"])}</td>'
+            div_rows += f'<td class="num">{d["quantity"]:,.0f}</td>'
+            div_rows += f'<td class="num" colspan="4">{err}</td></tr>'
+            continue
         cur_y = f"{d['current_yield']:.2f}%" if d.get("current_yield") is not None else "-"
         acq_y = f"{d['acq_yield']:.2f}%" if d.get("acq_yield") is not None else "-"
         div_rows += f'<tr><td><span class="code">{_h(d["code"])}</span> {_h(d["name"])}</td>'
@@ -992,6 +1021,9 @@ def _build_html(
   .dividend-total {{ font-size: 1.8rem; font-weight: 700; color: #0F7F30; margin-bottom: 2px; }}
   .dividend-total span {{ font-size: 0.9rem; color: #636e72; font-weight: 400; }}
   .dividend-monthly {{ font-size: 0.9rem; color: #636e72; margin-bottom: 8px; }}
+  .dividend-warning {{ background: #fff3e0; border-left: 3px solid #FCAD4C; padding: 8px 12px; font-size: 0.85rem; color: #8d6e2c; border-radius: 4px; margin-bottom: 8px; }}
+  .div-error {{ color: #999; font-style: italic; font-size: 0.85rem; }}
+  .div-err-row td {{ background: #fafafa; }}
   .compare-cards {{ display: flex; gap: 12px; margin-bottom: 20px; }}
   .compare-card {{ flex: 1; background: #fff; border-radius: 12px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); text-align: center; }}
   .compare-card h3 {{ font-size: 0.85rem; color: #636e72; margin-bottom: 6px; font-weight: 600; }}
@@ -1203,6 +1235,11 @@ def _build_html(
       </div>
       <div class="dividend-total">{total_dividend:,.0f}<span> 円/年</span></div>
       <div class="dividend-monthly">月平均 {total_dividend / 12:,.0f}円{_avg_yield_html(dividends)}</div>
+      {
+        f'<div class="dividend-warning">⚠ {dividend_error_count} 銘柄の配当を取得できませんでした（一覧の「取得エラー」行を参照）。集計には含まれていません。</div>'
+        if dividend_error_count > 0
+        else ""
+    }
       {
         f'''<div style="margin:16px 0;display:flex;align-items:center;gap:16px">
         <canvas id="yield-pie" width="140" height="140"></canvas>
@@ -2127,6 +2164,7 @@ def _demo_data() -> dict:
         "sector_totals": demo_sectors,
         "dividends": demo_dividends,
         "total_dividend": sum(d["annual"] for d in demo_dividends),
+        "dividend_error_count": 0,
         "yield_breakdown": demo_yield_breakdown,
         "sector_dividends": demo_sector_dividends,
         "volatility": 0.142,

--- a/tests/test_dividend_fetcher.py
+++ b/tests/test_dividend_fetcher.py
@@ -1,0 +1,94 @@
+"""dividend_fetcher の正規表現テスト（ネットワーク不要）。"""
+
+from __future__ import annotations
+
+from src.data import dividend_fetcher
+
+
+def _fake_fetch(html: str, monkeypatch) -> tuple[float | None, str | None]:
+    """fetch_dividend を urllib.request をモックして実行する。"""
+
+    class _FakeResp:
+        def __init__(self, body: str) -> None:
+            self._body = body.encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self) -> bytes:
+            return self._body
+
+    def fake_urlopen(req, timeout=10):
+        return _FakeResp(html)
+
+    monkeypatch.setattr(dividend_fetcher.urllib.request, "urlopen", fake_urlopen)
+    return dividend_fetcher.fetch_dividend("9999")
+
+
+def test_fetch_dividend_new_format(monkeypatch):
+    """新形式（JSON エスケープ付き）から dps と updateDate を抽出できる。"""
+    html = (
+        'foo bar \\"dps\\":{\\"name\\":\\"1株配当\\",\\"subText\\":\\"（予想）\\",'
+        '\\"value\\":\\"84.00\\",\\"updateDate\\":\\"2027/03\\",'
+        '\\"updateDateMeta\\":\\"2027-03-01\\",\\"suffix\\":\\"円\\"} baz'
+    )
+    dps, dps_date = _fake_fetch(html, monkeypatch)
+    assert dps == 84.0
+    assert dps_date == "2027/03"
+
+
+def test_fetch_dividend_legacy_format(monkeypatch):
+    """旧形式 ("dps":"...","dpsDate":"...") も引き続き読める。"""
+    html = 'something "dps":"145","dpsDate":"2027/03" something'
+    dps, dps_date = _fake_fetch(html, monkeypatch)
+    assert dps == 145.0
+    assert dps_date == "2027/03"
+
+
+def test_fetch_dividend_missing_returns_none(monkeypatch):
+    """ETF などで dps が掲載されていないページでは None を返す。"""
+    html = "<html>no dividend data here</html>"
+    dps, dps_date = _fake_fetch(html, monkeypatch)
+    assert dps is None
+    assert dps_date is None
+
+
+def test_get_dividend_returns_none_when_missing(monkeypatch, tmp_path):
+    """dividends.json に該当銘柄が無ければ None（ハードコードへのフォールバックは廃止）。"""
+    from src.data import stock_master
+
+    cache = tmp_path / "dividends.json"
+    cache.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(stock_master, "_DIVIDENDS_JSON", cache)
+    monkeypatch.setattr(stock_master, "_dividend_cache", None)
+    # STOCK_MASTER に登録されている銘柄でも、dividends.json に無ければ None
+    assert stock_master.get_dividend("9433") is None
+    assert stock_master.get_dividend("AAPL") is None
+
+
+def test_get_dividend_returns_none_when_dps_null(monkeypatch, tmp_path):
+    """dividends.json で dps が null（取得不可マーカー）の場合は None を返す。"""
+    from src.data import stock_master
+
+    cache = tmp_path / "dividends.json"
+    cache.write_text('{"1478": {"dps": null, "date": null, "fetched": "2026-05-24"}}', encoding="utf-8")
+    monkeypatch.setattr(stock_master, "_DIVIDENDS_JSON", cache)
+    monkeypatch.setattr(stock_master, "_dividend_cache", None)
+    assert stock_master.get_dividend("1478") is None
+
+
+def test_get_dividend_returns_value_when_present(monkeypatch, tmp_path):
+    """dividends.json に数値が入っていればそれを返す。"""
+    from src.data import stock_master
+
+    cache = tmp_path / "dividends.json"
+    cache.write_text(
+        '{"9433": {"dps": 84.0, "date": "2027/03", "fetched": "2026-05-24"}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(stock_master, "_DIVIDENDS_JSON", cache)
+    monkeypatch.setattr(stock_master, "_dividend_cache", None)
+    assert stock_master.get_dividend("9433") == 84.0

--- a/tests/test_server_html.py
+++ b/tests/test_server_html.py
@@ -383,6 +383,48 @@ class TestBudget:
         assert "/api/cf/budget" in self.html
 
 
+# --- 配当取得エラー表示 ---
+
+
+class TestDividendError:
+    """get_dividend が None を返した銘柄を「取得エラー」表示する。"""
+
+    def _base_data(self) -> dict:
+        d = _demo_data()
+        # 取得エラー銘柄を1件追加（dps=None, annual=None, error=True）
+        d["dividends"] = list(d["dividends"]) + [
+            {
+                "code": "9999",
+                "name": "取得不可テスト株",
+                "quantity": 100,
+                "dps": None,
+                "annual": None,
+                "current_yield": None,
+                "acq_yield": None,
+                "error": True,
+            }
+        ]
+        d["dividend_error_count"] = 1
+        return d
+
+    def test_error_row_rendered(self):
+        html = _build_html(self._base_data(), [self._base_data()["date"]])
+        assert "取得エラー" in html
+        assert "取得不可テスト株" in html
+
+    def test_warning_banner_rendered(self):
+        html = _build_html(self._base_data(), [self._base_data()["date"]])
+        assert '<div class="dividend-warning">' in html
+        assert "1 銘柄の配当を取得できませんでした" in html
+
+    def test_no_warning_when_zero_errors(self):
+        d = _demo_data()
+        d["dividend_error_count"] = 0
+        html = _build_html(d, [d["date"]])
+        # CSS 定義は残るが、警告バナー本体（<div>）は出ない
+        assert '<div class="dividend-warning">' not in html
+
+
 # --- デモデータ構造 ---
 
 


### PR DESCRIPTION
## Summary
- Yahoo Finance Japan の HTML が JSON エスケープ形式に変わり旧正規表現がマッチせず、日本株の配当予測がほぼ全てゼロ円になっていた問題を修正。
- 新形式 \`\\\"dps\\\":{...,\\\"value\\\":\\\"84.00\\\",\\\"updateDate\\\":\\\"2027/03\\\"}\` に対応する正規表現を追加し、旧形式もフォールバック保持。
- ハードコードフォールバック（古くなり誤情報の温床になっていた）を全廃。\`get_dividend\` は \`float | None\` を返し、取得不可な銘柄は UI で「取得エラー」と明示表示。
- ETF・無配株など Yahoo に dps が無い銘柄のセカンダリ取得経路は #77 で別途対応。

## 変更点
- \`src/data/dividend_fetcher.py\`: 新形式 regex 追加・null 保存
- \`src/data/stock_master.py\`: \`dividend\` ハードコード削除、\`get_dividend\` → \`float | None\`
- \`src/web/server.py\`: 取得エラー行 + 警告バナー、集計は None を除外
- \`src/analysis/ai_comment.py\`: None をスキップ
- \`tests/test_dividend_fetcher.py\` (new): regex 単体テスト + get_dividend 仕様テスト
- \`tests/test_server_html.py\`: 取得エラー UI のテストクラス追加

## 自動テスト（pytest で検証済み）
- [x] 新形式 / 旧形式 / 未検出ケースの regex マッチを確認
- [x] \`get_dividend\` が未登録銘柄・dps:null・正常値で正しく \`None\` または値を返す
- [x] 取得エラー銘柄が一覧で「取得エラー」行として描画される
- [x] \`dividend_error_count > 0\` のとき \`<div class=\"dividend-warning\">\` バナーが出る
- [x] \`dividend_error_count == 0\` のときバナーは出ない
- [x] 全 263 件 pass / ruff OK

## 人間が確認すること
- [ ] 本物データのダッシュボードで「年間配当予測」が正しい金額になっている
- [ ] 1478（iS高配当ETF）・4755（楽天）が「取得エラー」と表示され、警告バナーに \"⚠ 2 銘柄の配当を取得できませんでした\" が出る
- [ ] 業種別配当・利回り別内訳・加重平均利回りの数値が妥当

## 関連
- 後続: #77（minkabu 等フォールバック取得経路の追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)