### PR TITLE
ci: GitHub Actions の Node 20 廃止対応（actions を v5/v6 にバンプ）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -14,10 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      # peaceiris/actions-gh-pages はまだ Node 20 build。
+      # 2026-09-16 の Node 20 削除後も動くよう Node 24 を強制する。
+      # 公式 actions が Node 24 対応した v5/v6 を使えば本来不要だが、
+      # third-party が追随するまでの暫定。
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,9 +10,9 @@ jobs:
   dependency-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary
GitHub Actions ランナーから 2026-09-16 に Node 20 が削除される予定。3 つの workflow（ci / security / deploy-pages）で使用している actions を Node 24 対応版にバンプし、サードパーティ未対応分は env var で吸収する。

## 変更点
- `actions/checkout`: v4 → v5
- `actions/setup-python`: v5 → v6
- `peaceiris/actions-gh-pages`: v4 のまま（Node 24 対応版が未 release）
  - `deploy-pages.yml` の job env に `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` を追加して暫定吸収。コメントで「公式対応後に削除」と明記。

## テスト
- 全 3 workflow が CI 上で実行されて pass することで自己検証

## 参考
[Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)