### PR TITLE
feat: 配当取得を多段フォールバック化 (#77)

### DIFF
--- a/src/data/dividend_fetcher.py
+++ b/src/data/dividend_fetcher.py
@@ -1,4 +1,9 @@
-"""Yahoo Finance Japan から配当データを自動取得する。
+"""配当データを自動取得する（多段フォールバック）。
+
+取得経路の優先順:
+    1. Yahoo Finance Japan（`1株配当` の予想値）
+    2. minkabu（年間分配金。ETF 等で Yahoo に dps が無いケース向け）
+    3. Yahoo Finance Japan で dps が `---` だった銘柄 → 無配確定として 0 を保存
 
 使い方:
     python -m src.data.dividend_fetcher           # 全銘柄を取得
@@ -23,26 +28,97 @@ _DPS_RE_NEW = re.compile(
     r'\\"dps\\":\{[^{}]*?\\"value\\":\\"(\d+(?:\.\d+)?)\\"'
     r'(?:[^{}]*?\\"updateDate\\":\\"([^"\\]+)\\")?'
 )
+# value=\"---\" は「予想未定／無配」を示す Yahoo の特殊表現
+_DPS_RE_UNDEFINED = re.compile(r'\\"dps\\":\{[^{}]*?\\"value\\":\\"---\\"')
+
+_MINKABU_URL = "https://minkabu.jp/stock/{code}"
+# minkabu の銘柄ページの分配金行:
+#   <th ...>分配金<span ...>（注6）</span></th>
+#   <td ...><span class="fwb">110円</span><span class="fss">（年2回）</span></td>
+# 配当金行（株式の場合）も同じ構造。
+_MINKABU_DIV_RE = re.compile(
+    r"<th[^>]*>(?:分配金|配当金|1株配当)[^<]*(?:<span[^>]*>[^<]*</span>)?</th>"
+    r"\s*<td[^>]*>\s*<span[^>]*>([0-9.,]+)円</span>",
+    re.DOTALL,
+)
+
 _JSON_PATH = Path(__file__).resolve().parent.parent.parent / "data" / "dividends.json"
 
 
-def fetch_dividend(code: str) -> tuple[float | None, str | None]:
+def _http_get(url: str) -> str | None:
+    """HTML を取得する。失敗時 None。"""
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.read().decode("utf-8")
+    except Exception:
+        return None
+
+
+def _fetch_yahoo_jp(code: str) -> tuple[float | None, str | None, str | None]:
     """Yahoo Finance Japan から1銘柄の年間予想配当を取得する。
 
     Returns:
-        (dps, dps_date) — ETF等で未検出の場合は (None, None)
+        (dps, date, source):
+          - 数値が取れた場合 (dps, date, "yahoo_jp")
+          - dps=\"---\" の場合 (0.0, None, "yahoo_jp_undefined") — 無配確定として扱う
+          - HTML 取得失敗・抽出不可 (None, None, None)
     """
-    url = _YAHOO_URL.format(code=code)
-    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-    with urllib.request.urlopen(req, timeout=10) as resp:
-        html = resp.read().decode("utf-8")
-    # 新形式を優先、なければ旧形式にフォールバック
+    html = _http_get(_YAHOO_URL.format(code=code))
+    if html is None:
+        return None, None, None
     m = _DPS_RE_NEW.search(html)
     if m is None:
         m = _DPS_RE_LEGACY.search(html)
+    if m is not None:
+        return float(m.group(1)), m.group(2), "yahoo_jp"
+    # value=\"---\"（無配確定）の検出
+    if _DPS_RE_UNDEFINED.search(html):
+        return 0.0, None, "yahoo_jp_undefined"
+    return None, None, None
+
+
+def _fetch_minkabu(code: str) -> tuple[float | None, str | None, str | None]:
+    """minkabu から年間分配金/配当金を取得する。
+
+    ETF の分配金や、Yahoo に dps が掲載されない銘柄向けのセカンダリ経路。
+
+    Returns:
+        (dps, date, source):
+          - 取れた場合 (dps, None, "minkabu") — minkabu は権利確定日を出していないため date は None
+          - 取れなければ (None, None, None)
+    """
+    html = _http_get(_MINKABU_URL.format(code=code))
+    if html is None:
+        return None, None, None
+    m = _MINKABU_DIV_RE.search(html)
     if m is None:
-        return None, None
-    return float(m.group(1)), m.group(2)
+        return None, None, None
+    try:
+        return float(m.group(1).replace(",", "")), None, "minkabu"
+    except ValueError:
+        return None, None, None
+
+
+def fetch_dividend(code: str) -> tuple[float | None, str | None, str | None]:
+    """多段フォールバックで配当を取得する。
+
+    Returns:
+        (dps, date, source):
+          - source は "yahoo_jp" | "yahoo_jp_undefined" | "minkabu" | None
+          - 全経路失敗時 (None, None, None)
+    """
+    dps, dps_date, source = _fetch_yahoo_jp(code)
+    if dps is not None and source == "yahoo_jp":
+        return dps, dps_date, source
+    # Yahoo に dps が無い、または dps=\"---\"（無配） → minkabu を試す
+    m_dps, m_date, m_source = _fetch_minkabu(code)
+    if m_dps is not None:
+        return m_dps, m_date, m_source
+    # minkabu でも取れない → Yahoo の "---"（無配確定）情報があればそれを採用
+    if source == "yahoo_jp_undefined":
+        return 0.0, None, source
+    return None, None, None
 
 
 def update_all_dividends(codes: list[str] | None = None) -> dict:
@@ -62,15 +138,15 @@ def update_all_dividends(codes: list[str] | None = None) -> dict:
     for i, code in enumerate(codes):
         print(f"  [{i + 1}/{len(codes)}] {code} ... ", end="", flush=True)
         try:
-            dps, dps_date = fetch_dividend(code)
+            dps, dps_date, source = fetch_dividend(code)
             if dps is not None:
-                data[code] = {"dps": dps, "date": dps_date, "fetched": today}
-                print(f"{dps}円 ({dps_date})")
+                data[code] = {"dps": dps, "date": dps_date, "fetched": today, "source": source}
+                date_str = f" ({dps_date})" if dps_date else ""
+                print(f"{dps}円{date_str} [{source}]")
             else:
-                # ETF や無配確定銘柄など dps を抽出できなかったケースは null で保存し、
-                # UI 側で「取得エラー」として扱う（ハードコード値にはフォールバックしない）
-                data[code] = {"dps": None, "date": None, "fetched": today}
-                print("取得不可（dps 未検出）")
+                # 全経路失敗 → null で保存。UI で「取得エラー」表示
+                data[code] = {"dps": None, "date": None, "fetched": today, "source": None}
+                print("取得不可（全経路失敗）")
         except Exception as e:
             print(f"エラー: {e}")
         if i < len(codes) - 1:

--- a/tests/test_dividend_fetcher.py
+++ b/tests/test_dividend_fetcher.py
@@ -1,92 +1,191 @@
-"""dividend_fetcher の正規表現テスト（ネットワーク不要）。"""
+"""dividend_fetcher の単体テスト（ネットワーク不要）。"""
 
 from __future__ import annotations
 
 from src.data import dividend_fetcher
 
 
-def _fake_fetch(html: str, monkeypatch) -> tuple[float | None, str | None]:
-    """fetch_dividend を urllib.request をモックして実行する。"""
+def _make_fake_get(yahoo_html: str | None, minkabu_html: str | None):
+    """`_http_get` を URL ごとに別 HTML を返すフェイクに置き換えるヘルパ。"""
 
-    class _FakeResp:
-        def __init__(self, body: str) -> None:
-            self._body = body.encode("utf-8")
+    def fake_get(url: str) -> str | None:
+        if "minkabu" in url:
+            return minkabu_html
+        return yahoo_html
 
-        def __enter__(self):
-            return self
+    return fake_get
 
-        def __exit__(self, *exc):
-            return False
 
-        def read(self) -> bytes:
-            return self._body
-
-    def fake_urlopen(req, timeout=10):
-        return _FakeResp(html)
-
-    monkeypatch.setattr(dividend_fetcher.urllib.request, "urlopen", fake_urlopen)
+def _fetch(monkeypatch, yahoo_html=None, minkabu_html=None):
+    monkeypatch.setattr(dividend_fetcher, "_http_get", _make_fake_get(yahoo_html, minkabu_html))
     return dividend_fetcher.fetch_dividend("9999")
 
 
-def test_fetch_dividend_new_format(monkeypatch):
-    """新形式（JSON エスケープ付き）から dps と updateDate を抽出できる。"""
-    html = (
-        'foo bar \\"dps\\":{\\"name\\":\\"1株配当\\",\\"subText\\":\\"（予想）\\",'
+# --- Yahoo Finance Japan の DPS 抽出 ---
+
+
+def test_yahoo_new_format(monkeypatch):
+    """新形式（JSON エスケープ付き）から dps と updateDate を抽出。"""
+    yahoo = (
+        'foo \\"dps\\":{\\"name\\":\\"1株配当\\",\\"subText\\":\\"（予想）\\",'
         '\\"value\\":\\"84.00\\",\\"updateDate\\":\\"2027/03\\",'
-        '\\"updateDateMeta\\":\\"2027-03-01\\",\\"suffix\\":\\"円\\"} baz'
+        '\\"updateDateMeta\\":\\"2027-03-01\\",\\"suffix\\":\\"円\\"} bar'
     )
-    dps, dps_date = _fake_fetch(html, monkeypatch)
+    dps, dps_date, source = _fetch(monkeypatch, yahoo_html=yahoo)
     assert dps == 84.0
     assert dps_date == "2027/03"
+    assert source == "yahoo_jp"
 
 
-def test_fetch_dividend_legacy_format(monkeypatch):
+def test_yahoo_legacy_format(monkeypatch):
     """旧形式 ("dps":"...","dpsDate":"...") も引き続き読める。"""
-    html = 'something "dps":"145","dpsDate":"2027/03" something'
-    dps, dps_date = _fake_fetch(html, monkeypatch)
+    yahoo = 'something "dps":"145","dpsDate":"2027/03" something'
+    dps, dps_date, source = _fetch(monkeypatch, yahoo_html=yahoo)
     assert dps == 145.0
     assert dps_date == "2027/03"
+    assert source == "yahoo_jp"
 
 
-def test_fetch_dividend_missing_returns_none(monkeypatch):
-    """ETF などで dps が掲載されていないページでは None を返す。"""
-    html = "<html>no dividend data here</html>"
-    dps, dps_date = _fake_fetch(html, monkeypatch)
+# --- "---" 検知（無配確定） ---
+
+
+def test_yahoo_undefined_with_no_minkabu(monkeypatch):
+    """Yahoo dps=\"---\" + minkabu でも取れない → 無配確定として 0 円。"""
+    yahoo = '\\"dps\\":{\\"name\\":\\"1株配当\\",\\"value\\":\\"---\\",\\"updateDate\\":\\"2026/12\\"}'
+    minkabu = "<html>no dividend</html>"
+    dps, dps_date, source = _fetch(monkeypatch, yahoo_html=yahoo, minkabu_html=minkabu)
+    assert dps == 0.0
+    assert dps_date is None
+    assert source == "yahoo_jp_undefined"
+
+
+# --- minkabu フォールバック ---
+
+
+def test_minkabu_fallback_when_yahoo_missing(monkeypatch):
+    """Yahoo で dps が見つからず、minkabu に分配金がある → minkabu を採用。"""
+    yahoo = "<html>no dps json here</html>"
+    minkabu = (
+        '<th class="x">分配金<span class="fss">（注6）</span></th>'
+        '\n<td class="y"><span class="fwb">110円</span><span class="fss">（年2回）</span></td>'
+    )
+    dps, dps_date, source = _fetch(monkeypatch, yahoo_html=yahoo, minkabu_html=minkabu)
+    assert dps == 110.0
+    assert dps_date is None
+    assert source == "minkabu"
+
+
+def test_minkabu_overrides_yahoo_undefined(monkeypatch):
+    """Yahoo dps=\"---\" だが minkabu に値がある → minkabu を優先採用。"""
+    yahoo = '\\"dps\\":{\\"value\\":\\"---\\"}'
+    minkabu = '<th>分配金</th>\n<td><span class="fwb">110円</span>'
+    dps, dps_date, source = _fetch(monkeypatch, yahoo_html=yahoo, minkabu_html=minkabu)
+    assert dps == 110.0
+    assert source == "minkabu"
+
+
+def test_minkabu_with_comma_value(monkeypatch):
+    """minkabu 側がカンマ付き数値（1,234円）でも数値化できる。"""
+    yahoo = "<html>none</html>"
+    minkabu = '<th>配当金</th>\n<td><span class="fwb">1,234円</span>'
+    dps, _, source = _fetch(monkeypatch, yahoo_html=yahoo, minkabu_html=minkabu)
+    assert dps == 1234.0
+    assert source == "minkabu"
+
+
+# --- 優先順 ---
+
+
+def test_yahoo_takes_precedence_over_minkabu(monkeypatch):
+    """Yahoo で数値が取れたら minkabu は呼ばれない（呼ばれても結果は Yahoo 優先）。"""
+    yahoo = '\\"dps\\":{\\"name\\":\\"1株配当\\",\\"value\\":\\"84.00\\",\\"updateDate\\":\\"2027/03\\"}'
+    minkabu = '<th>配当金</th>\n<td><span class="fwb">999円</span>'
+    dps, _, source = _fetch(monkeypatch, yahoo_html=yahoo, minkabu_html=minkabu)
+    assert dps == 84.0
+    assert source == "yahoo_jp"
+
+
+def test_minkabu_not_called_when_yahoo_succeeds(monkeypatch):
+    """Yahoo で成功すれば minkabu の HTTP は走らない（外部リクエスト数を最小化）。"""
+    calls: list[str] = []
+
+    def tracking_get(url: str) -> str | None:
+        calls.append(url)
+        if "yahoo" in url:
+            return '\\"dps\\":{\\"value\\":\\"84.00\\",\\"updateDate\\":\\"2027/03\\"}'
+        return None
+
+    monkeypatch.setattr(dividend_fetcher, "_http_get", tracking_get)
+    dividend_fetcher.fetch_dividend("9999")
+    assert any("yahoo" in u for u in calls)
+    assert not any("minkabu" in u for u in calls), f"minkabu was called: {calls}"
+
+
+# --- 全経路失敗 ---
+
+
+def test_all_paths_fail_returns_none(monkeypatch):
+    """Yahoo に dps なし・"---" なし・minkabu にも無し → 全 None。"""
+    dps, dps_date, source = _fetch(
+        monkeypatch,
+        yahoo_html="<html>nothing here</html>",
+        minkabu_html="<html>nothing here either</html>",
+    )
     assert dps is None
     assert dps_date is None
+    assert source is None
+
+
+# --- get_dividend（呼び出し側）の挙動 ---
 
 
 def test_get_dividend_returns_none_when_missing(monkeypatch, tmp_path):
-    """dividends.json に該当銘柄が無ければ None（ハードコードへのフォールバックは廃止）。"""
+    """dividends.json に該当銘柄が無ければ None。"""
     from src.data import stock_master
 
     cache = tmp_path / "dividends.json"
     cache.write_text("{}", encoding="utf-8")
     monkeypatch.setattr(stock_master, "_DIVIDENDS_JSON", cache)
     monkeypatch.setattr(stock_master, "_dividend_cache", None)
-    # STOCK_MASTER に登録されている銘柄でも、dividends.json に無ければ None
     assert stock_master.get_dividend("9433") is None
     assert stock_master.get_dividend("AAPL") is None
 
 
 def test_get_dividend_returns_none_when_dps_null(monkeypatch, tmp_path):
-    """dividends.json で dps が null（取得不可マーカー）の場合は None を返す。"""
+    """dividends.json の dps が null（全経路失敗マーカー）→ None。"""
     from src.data import stock_master
 
     cache = tmp_path / "dividends.json"
-    cache.write_text('{"1478": {"dps": null, "date": null, "fetched": "2026-05-24"}}', encoding="utf-8")
+    cache.write_text(
+        '{"1478": {"dps": null, "date": null, "fetched": "2026-05-24", "source": null}}',
+        encoding="utf-8",
+    )
     monkeypatch.setattr(stock_master, "_DIVIDENDS_JSON", cache)
     monkeypatch.setattr(stock_master, "_dividend_cache", None)
     assert stock_master.get_dividend("1478") is None
 
 
-def test_get_dividend_returns_value_when_present(monkeypatch, tmp_path):
-    """dividends.json に数値が入っていればそれを返す。"""
+def test_get_dividend_returns_zero_when_explicit_zero(monkeypatch, tmp_path):
+    """dps: 0（無配確定）はそのまま 0.0 を返す（None と区別する）。"""
     from src.data import stock_master
 
     cache = tmp_path / "dividends.json"
     cache.write_text(
-        '{"9433": {"dps": 84.0, "date": "2027/03", "fetched": "2026-05-24"}}',
+        '{"4755": {"dps": 0, "date": null, "fetched": "2026-05-24", "source": "yahoo_jp_undefined"}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(stock_master, "_DIVIDENDS_JSON", cache)
+    monkeypatch.setattr(stock_master, "_dividend_cache", None)
+    assert stock_master.get_dividend("4755") == 0.0
+
+
+def test_get_dividend_returns_value_when_present(monkeypatch, tmp_path):
+    """通常の数値はそのまま返す。"""
+    from src.data import stock_master
+
+    cache = tmp_path / "dividends.json"
+    cache.write_text(
+        '{"9433": {"dps": 84.0, "date": "2027/03", "fetched": "2026-05-24", "source": "yahoo_jp"}}',
         encoding="utf-8",
     )
     monkeypatch.setattr(stock_master, "_DIVIDENDS_JSON", cache)


### PR DESCRIPTION
## Summary
ETF・無配確定銘柄など Yahoo Finance Japan で dps が取れない銘柄向けに、minkabu を 2 次経路として追加。取得元を `source` フィールドで明示する。

## 取得経路の優先順
1. **Yahoo Finance Japan** の 1株配当（予想値）
2. **minkabu** の分配金/配当金/1株配当
3. Yahoo dps=`"---"` 検知 → 無配確定として `0` を保存

## 実銘柄での検証
| 銘柄 | 旧挙動 | 新挙動 |
|------|--------|--------|
| 1478 iS高配当ETF | 取得エラー | **110円** [minkabu] |
| 4755 楽天グループ | 取得エラー | **0円**（無配確定） [yahoo_jp_undefined] |
| 9433 KDDI | 84円 [yahoo_jp] | 84円 [yahoo_jp]（minkabu は呼ばれない） |
| その他 11 銘柄 | 取得済 | 取得済（変化なし） |

## 自動テスト（pytest で検証済み）
- [x] 新形式 Yahoo HTML から dps を抽出
- [x] 旧形式 Yahoo HTML も引き続き読める
- [x] Yahoo dps=`"---"` + minkabu 該当なし → 0 円
- [x] Yahoo 不在で minkabu 該当あり → minkabu 採用
- [x] Yahoo `"---"` + minkabu 該当あり → minkabu 優先
- [x] minkabu のカンマ付き数値（1,234円）も数値化
- [x] Yahoo 優先（minkabu 値より Yahoo を採用）
- [x] Yahoo で成功すれば minkabu の HTTP は呼ばれない
- [x] 全経路失敗 → (None, None, None)
- [x] `get_dividend` が `dps:0`（無配確定）と `dps:null`（取得不可）を区別

全 13 件 + 既存 278 件、合計 pass。HTTP は全モックでネットワーク不要。

## 人間が確認すること
- [ ] ダッシュボードで 1478 が「110円 / 利回り …%」と表示される（取得エラー行ではなくなる）
- [ ] 4755 楽天は配当 0 円扱いとなり、警告バナーから消える
- [ ] 警告バナー「⚠ 0 銘柄の配当を取得できませんでした」が消える / または件数が減る
- [ ] minkabu のレート制限に該当しないか（13 銘柄 × 1 秒間隔で実行ログを確認）

## スコープ外（フォローアップ）
米国株（AAPL, MSFT, VOO 等）の Yahoo Finance US 経路追加は本 PR では対応せず別途。`dividends.json` 内の米国株データは手動で残っている状態。

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)