### PR TITLE
サーバー内蔵スケジューラで日次データ自動収集 (#58)

### DIFF
--- a/src/web/server.py
+++ b/src/web/server.py
@@ -7875,6 +7875,12 @@ def _scheduler_tick(db_path: str, now: datetime) -> None:
     if not _should_run_scheduled(now, scheduled_time, last_run_at):
         return
 
+    if _update_state["running"]:
+        # 起動時更新の実行中は試行時刻を保存せず、次の tick に判定を持ち越す。
+        # ここで保存すると、起動時更新が失敗した場合に当日の再取得機会を失う。
+        logger.info("[scheduler] 更新が既に実行中のため次回の判定に持ち越し")
+        return
+
     # 実行前に試行時刻を保存する — 失敗時に毎分リトライし続けるのを防ぐ（再試行は翌日）
     conn = init_db(db_path)
     try:
@@ -7882,10 +7888,7 @@ def _scheduler_tick(db_path: str, now: datetime) -> None:
     finally:
         conn.close()
 
-    if _update_state["running"]:
-        result = "skipped"
-        logger.info("[scheduler] 更新が既に実行中のためスキップ")
-    elif not _should_update(db_path, max_age_hours=1):
+    if not _should_update(db_path, max_age_hours=1):
         result = "skipped"
         logger.info("[scheduler] データが新しいためスキップ")
     else:

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -651,9 +651,22 @@ def _build_html(
     ai_comment: str | None = None,
     demo: bool = False,
     session_expired: str | None = None,
+    last_fetch_at: str | None = None,
+    next_run_at: str | None = None,
 ) -> str:
     if not data:
         return "<html><body><h1>データがありません</h1></body></html>"
+
+    fetch_parts = []
+    if last_fetch_at:
+        fetch_parts.append(f"最終取得: {last_fetch_at}")
+    if next_run_at:
+        fetch_parts.append(f"次回自動取得: {next_run_at}")
+    fetch_status_html = (
+        f'<div style="font-size:0.78rem;color:#b2bec3;margin-bottom:12px">{" ／ ".join(fetch_parts)}</div>'
+        if fetch_parts
+        else ""
+    )
 
     date = data["date"]
     total = data["total_asset"]
@@ -1133,6 +1146,7 @@ def _build_html(
     <button class="nav-btn" id="next-btn" title="次の日">&rarr;</button>
     <label>({len(dates)}日分のデータ)</label>
   </div>
+  {fetch_status_html}
   <div class="total">現在の総資産: <strong>{total:,.0f}</strong> 円 <span style="font-size:0.85rem;color:#b2bec3">({
         date
     }時点)</span></div>
@@ -6544,22 +6558,44 @@ class Handler(BaseHTTPRequestHandler):
                             conn.close()
                     except Exception:
                         pass
-            # セッション切れチェック
+            # セッション切れチェック + 取得日時ステータス
             session_expired = None
+            last_fetch_at = None
+            next_run_at = None
             if self.demo:
                 # デモモード: ?session_expired=1 で強制表示（見た目確認用）
                 if params.get("session_expired", [""])[0]:
                     session_expired = "demo"
+                last_fetch_at = f"{data['date']} 07:00"
+                next_run_at = "明日 07:00"
             else:
                 try:
                     conn = get_connection(self.db_path)
                     try:
                         session_expired = get_setting(conn, "session_expired")
+                        last_fetch_raw = get_setting(conn, "last_fetch_at")
+                        scheduler_enabled = get_setting(conn, "scheduler_enabled", "1") != "0"
+                        scheduler_time = get_setting(conn, "scheduler_time", _SCHEDULER_DEFAULT_TIME)
                     finally:
                         conn.close()
+                    if last_fetch_raw:
+                        with contextlib.suppress(ValueError):
+                            last_fetch_at = datetime.fromisoformat(last_fetch_raw).strftime("%Y-%m-%d %H:%M")
+                    if self.skip_update or not scheduler_enabled:
+                        next_run_at = "オフ"
+                    else:
+                        next_run_at = _next_scheduled_run(datetime.now(), scheduler_time).strftime("%m-%d %H:%M")
                 except Exception:
                     pass
-            html = _build_html(data, dates, self.skip_update, ai_comment=ai_comment, session_expired=session_expired)
+            html = _build_html(
+                data,
+                dates,
+                self.skip_update,
+                ai_comment=ai_comment,
+                session_expired=session_expired,
+                last_fetch_at=last_fetch_at,
+                next_run_at=next_run_at,
+            )
             self._send_html(html)
 
         elif parsed.path == "/cf":

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -4752,8 +4752,8 @@ const pollId = setInterval(async () => {{
 </html>"""
 
 
-def _build_settings_html(db_path: str, saved: str | None = None) -> str:
-    """設定ページのHTMLを生成する。"""
+def _build_settings_html(db_path: str, saved: str | None = None, skip_update: bool = False) -> str:
+    """設定ページのHTMLを生成する。skip_update はスケジューラが起動していないモード。"""
     import os
 
     conn = get_connection(db_path)
@@ -4775,7 +4775,9 @@ def _build_settings_html(db_path: str, saved: str | None = None) -> str:
         with contextlib.suppress(ValueError):
             last_run_disp = datetime.fromisoformat(scheduler_last_run).strftime("%Y-%m-%d %H:%M")
             scheduler_status = f"最終実行: {last_run_disp}" + (f" — {result_label}" if result_label else "")
-    if scheduler_enabled:
+    if skip_update:
+        scheduler_status += " ／ 自動取得: 停止中（--demo / --skip-update で起動中）"
+    elif scheduler_enabled:
         next_run = _next_scheduled_run(datetime.now(), scheduler_time)
         scheduler_status += f" ／ 次回予定: {next_run.strftime('%Y-%m-%d %H:%M')}"
     else:
@@ -4792,11 +4794,16 @@ def _build_settings_html(db_path: str, saved: str | None = None) -> str:
         source = ""
         display_key = ""
 
-    saved_msg = (
-        '<div class="saved-msg">設定を保存しました。AIコメントをバックグラウンドで生成中です — 数十秒後にダッシュボードを開くと表示されます。</div>'
-        if saved
-        else ""
-    )
+    # 保存メッセージは setting_type ごとに分岐（"1" は旧URL互換で gemini 扱い）
+    if saved in ("gemini", "1"):
+        saved_msg = (
+            '<div class="saved-msg">設定を保存しました。AIコメントをバックグラウンドで生成中です'
+            " — 数十秒後にダッシュボードを開くと表示されます。</div>"
+        )
+    elif saved:
+        saved_msg = '<div class="saved-msg">設定を保存しました。</div>'
+    else:
+        saved_msg = ""
 
     return f"""<!DOCTYPE html>
 <html lang="ja">
@@ -6639,7 +6646,7 @@ class Handler(BaseHTTPRequestHandler):
 
         elif parsed.path == "/settings":
             saved = params.get("saved", [None])[0]
-            html = _build_settings_html(self.db_path, saved=saved)
+            html = _build_settings_html(self.db_path, saved=saved, skip_update=self.skip_update)
             self._send_html(html)
 
         elif parsed.path == "/api/export/snapshots":
@@ -7008,6 +7015,9 @@ class Handler(BaseHTTPRequestHandler):
             body = self.rfile.read(length).decode()
             post_params = parse_qs(body)
             setting_type = post_params.get("setting_type", ["gemini"])[0]
+            # リダイレクト URL に反映するためホワイトリストで正規化
+            if setting_type not in ("closing_day", "scheduler"):
+                setting_type = "gemini"
 
             if setting_type == "closing_day":
                 # 締め日設定
@@ -7058,7 +7068,7 @@ class Handler(BaseHTTPRequestHandler):
                     t = threading.Thread(target=_generate_ai_comments, args=(self.db_path,), daemon=True)
                     t.start()
             self.send_response(303)
-            self.send_header("Location", "/settings?saved=1")
+            self.send_header("Location", f"/settings?saved={setting_type}")
             self.end_headers()
 
         elif parsed.path == "/api/life-events":
@@ -7807,6 +7817,14 @@ def _bg_worker(db_path: str) -> None:
     if not _update_lock.acquire(blocking=False):
         logger.info("[auto] 更新は既に実行中 — スキップ")
         return
+    try:
+        _run_update_locked(db_path)
+    finally:
+        _update_lock.release()
+
+
+def _run_update_locked(db_path: str) -> None:
+    """データ取得・配当更新・AI分析の本体。_update_lock を取得済みの前提で呼ぶこと。"""
     _update_state["running"] = True
     try:
         import asyncio
@@ -7847,11 +7865,17 @@ def _bg_worker(db_path: str) -> None:
             logger.error("[auto] バックグラウンド更新失敗: %s", e)
     finally:
         _update_state["running"] = False
-        _update_lock.release()
 
 
 def _scheduler_tick(db_path: str, now: datetime) -> None:
-    """設定を読み、実行時刻に達していればデータ取得を1回実行する。"""
+    """設定を読み、実行時刻に達していればデータ取得を1回実行する。
+
+    取得はスケジューラスレッド上で同期実行する（完了まで次の tick は遅れるが、
+    試行時刻を先に保存するため二重実行は起きない）。
+    実行時刻を当日中に後ろへ変更した場合、新しい時刻で同日もう1回実行される
+    （人間がテストのため「数分後」に設定する操作を想定した意図的な仕様。
+    直近1時間以内に取得済みなら _should_update が抑止する）。
+    """
     conn = init_db(db_path)
     try:
         enabled = get_setting(conn, "scheduler_enabled", "1") != "0"
@@ -7875,33 +7899,37 @@ def _scheduler_tick(db_path: str, now: datetime) -> None:
     if not _should_run_scheduled(now, scheduled_time, last_run_at):
         return
 
-    if _update_state["running"]:
-        # 起動時更新の実行中は試行時刻を保存せず、次の tick に判定を持ち越す。
-        # ここで保存すると、起動時更新が失敗した場合に当日の再取得機会を失う。
+    # 起動時更新と排他するため、ロックを取得してから試行時刻の保存・実行を行う
+    # （running フラグの確認と実行の間に他スレッドが割り込むのを防ぐ）。
+    # 取得できないときは試行時刻を保存せず、次の tick に判定を持ち越す —
+    # ここで保存すると、起動時更新が失敗した場合に当日の再取得機会を失う。
+    if not _update_lock.acquire(blocking=False):
         logger.info("[scheduler] 更新が既に実行中のため次回の判定に持ち越し")
         return
-
-    # 実行前に試行時刻を保存する — 失敗時に毎分リトライし続けるのを防ぐ（再試行は翌日）
-    conn = init_db(db_path)
     try:
-        save_setting(conn, "scheduler_last_run_at", now.isoformat())
-    finally:
-        conn.close()
-
-    if not _should_update(db_path, max_age_hours=1):
-        result = "skipped"
-        logger.info("[scheduler] データが新しいためスキップ")
-    else:
-        logger.info("[scheduler] 定時データ取得を開始します...")
-        _bg_worker(db_path)
+        # 実行前に試行時刻を保存する — 失敗時に毎分リトライし続けるのを防ぐ（再試行は翌日）
         conn = init_db(db_path)
         try:
-            fetched = get_setting(conn, "last_fetch_at")
+            save_setting(conn, "scheduler_last_run_at", now.isoformat())
         finally:
             conn.close()
-        success = bool(fetched) and fetched != last_fetch_raw
-        result = "success" if success else "failure"
-        logger.info("[scheduler] 定時データ取得: %s", result)
+
+        if not _should_update(db_path, max_age_hours=1):
+            result = "skipped"
+            logger.info("[scheduler] データが新しいためスキップ")
+        else:
+            logger.info("[scheduler] 定時データ取得を開始します...")
+            _run_update_locked(db_path)
+            conn = init_db(db_path)
+            try:
+                fetched = get_setting(conn, "last_fetch_at")
+            finally:
+                conn.close()
+            success = bool(fetched) and fetched != last_fetch_raw
+            result = "success" if success else "failure"
+            logger.info("[scheduler] 定時データ取得: %s", result)
+    finally:
+        _update_lock.release()
 
     conn = init_db(db_path)
     try:

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -14,6 +14,7 @@ import logging
 import math
 import sqlite3
 import threading
+import time
 import unicodedata
 from datetime import date, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -74,6 +75,10 @@ logger = logging.getLogger(__name__)
 DB_DEFAULT = Path(__file__).resolve().parents[2] / "data" / "assets.db"
 
 _update_state = {"running": False, "version": 0}
+_update_lock = threading.Lock()
+
+_SCHEDULER_CHECK_INTERVAL = 60  # 秒
+_SCHEDULER_DEFAULT_TIME = "07:00"
 
 
 def _h(s: str) -> str:
@@ -7706,7 +7711,13 @@ def _generate_ai_comments(db_path: str) -> None:
 
 
 def _bg_worker(db_path: str) -> None:
-    """バックグラウンドでデータ取得・配当更新・AI分析を実行する。"""
+    """バックグラウンドでデータ取得・配当更新・AI分析を実行する。
+
+    起動時更新スレッドとスケジューラスレッドの同時発火を _update_lock で1本に抑える。
+    """
+    if not _update_lock.acquire(blocking=False):
+        logger.info("[auto] 更新は既に実行中 — スキップ")
+        return
     _update_state["running"] = True
     try:
         import asyncio
@@ -7747,6 +7758,81 @@ def _bg_worker(db_path: str) -> None:
             logger.error("[auto] バックグラウンド更新失敗: %s", e)
     finally:
         _update_state["running"] = False
+        _update_lock.release()
+
+
+def _scheduler_tick(db_path: str, now: datetime) -> None:
+    """設定を読み、実行時刻に達していればデータ取得を1回実行する。"""
+    conn = init_db(db_path)
+    try:
+        enabled = get_setting(conn, "scheduler_enabled", "1") != "0"
+        scheduled_time = get_setting(conn, "scheduler_time", _SCHEDULER_DEFAULT_TIME)
+        last_run_raw = get_setting(conn, "scheduler_last_run_at")
+        last_fetch_raw = get_setting(conn, "last_fetch_at")
+    finally:
+        conn.close()
+
+    if not enabled:
+        return
+
+    # 前回のスケジュール試行と起動時更新の成功時刻のうち、新しい方を「前回実行」とみなす
+    candidates = []
+    for raw in (last_run_raw, last_fetch_raw):
+        if raw:
+            with contextlib.suppress(ValueError):
+                candidates.append(datetime.fromisoformat(raw))
+    last_run_at = max(candidates) if candidates else None
+
+    if not _should_run_scheduled(now, scheduled_time, last_run_at):
+        return
+
+    # 実行前に試行時刻を保存する — 失敗時に毎分リトライし続けるのを防ぐ（再試行は翌日）
+    conn = init_db(db_path)
+    try:
+        save_setting(conn, "scheduler_last_run_at", now.isoformat())
+    finally:
+        conn.close()
+
+    if _update_state["running"]:
+        result = "skipped"
+        logger.info("[scheduler] 更新が既に実行中のためスキップ")
+    elif not _should_update(db_path, max_age_hours=1):
+        result = "skipped"
+        logger.info("[scheduler] データが新しいためスキップ")
+    else:
+        logger.info("[scheduler] 定時データ取得を開始します...")
+        _bg_worker(db_path)
+        conn = init_db(db_path)
+        try:
+            fetched = get_setting(conn, "last_fetch_at")
+        finally:
+            conn.close()
+        success = bool(fetched) and fetched != last_fetch_raw
+        result = "success" if success else "failure"
+        logger.info("[scheduler] 定時データ取得: %s", result)
+
+    conn = init_db(db_path)
+    try:
+        save_setting(conn, "scheduler_last_result", result)
+    finally:
+        conn.close()
+
+
+def _scheduler_loop(db_path: str) -> None:
+    """毎分設定を読み直し、実行時刻判定が True ならデータ取得を実行する常駐ループ。"""
+    while True:
+        time.sleep(_SCHEDULER_CHECK_INTERVAL)
+        try:
+            _scheduler_tick(db_path, now=datetime.now())
+        except Exception as e:
+            logger.error("[scheduler] tick エラー: %s", e)
+
+
+def _start_scheduler(db_path: str) -> None:
+    """スケジューラスレッドを起動する。"""
+    t = threading.Thread(target=_scheduler_loop, args=(db_path,), daemon=True)
+    t.start()
+    logger.info("[scheduler] スケジューラを開始しました（毎分チェック）")
 
 
 def _start_bg_update(db_path: str) -> None:
@@ -7804,6 +7890,7 @@ def main() -> None:
     skip_update = args.demo or args.skip_update
     if not skip_update:
         _start_bg_update(args.db)
+        _start_scheduler(args.db)
 
     Handler.db_path = args.db
     Handler.demo = args.demo

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -15,7 +15,7 @@ import math
 import sqlite3
 import threading
 import unicodedata
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -7649,6 +7649,40 @@ def _should_update(db_path: str, max_age_hours: int = 6) -> bool:
 
     elapsed = datetime.now() - datetime.fromisoformat(last)
     return elapsed.total_seconds() >= max_age_hours * 3600
+
+
+def _parse_scheduler_time(value: str | None) -> tuple[int, int]:
+    """ "HH:MM" 形式の文字列を (hour, minute) に変換する。不正値は (7, 0) にフォールバック。"""
+    if value:
+        with contextlib.suppress(ValueError):
+            t = datetime.strptime(value, "%H:%M")
+            return t.hour, t.minute
+    return 7, 0
+
+
+def _should_run_scheduled(now: datetime, scheduled_time: str | None, last_run_at: datetime | None) -> bool:
+    """当日の予定時刻を過ぎていて、前回実行がその時刻より前なら True。
+
+    経過時間（24時間以上）の比較ではなく「前回実行 < 当日の予定時刻」のスロット比較に
+    することで、チェック間隔の粒度による実行時刻のずれ（drift）を防ぐ。
+    サーバーが予定時刻に停止していた場合も、起動後の最初の判定で True になる（追いつき実行）。
+    """
+    hour, minute = _parse_scheduler_time(scheduled_time)
+    target = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if now < target:
+        return False
+    if last_run_at is None:
+        return True
+    return last_run_at < target
+
+
+def _next_scheduled_run(now: datetime, scheduled_time: str | None) -> datetime:
+    """次回の実行予定時刻。当日の予定時刻が未来ならそれ、過ぎていれば翌日。"""
+    hour, minute = _parse_scheduler_time(scheduled_time)
+    target = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if now < target:
+        return target
+    return target + timedelta(days=1)
 
 
 def _needs_dividend_update() -> bool:

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -4747,8 +4747,25 @@ def _build_settings_html(db_path: str, saved: str | None = None) -> str:
         db_key = get_setting(conn, "gemini_api_key", "")
         closing_day = int(get_setting(conn, "closing_day", "1") or "1")
         holiday_mode = get_setting(conn, "closing_day_holiday", "none") or "none"
+        scheduler_enabled = get_setting(conn, "scheduler_enabled", "1") != "0"
+        scheduler_time = get_setting(conn, "scheduler_time", _SCHEDULER_DEFAULT_TIME) or _SCHEDULER_DEFAULT_TIME
+        scheduler_last_run = get_setting(conn, "scheduler_last_run_at")
+        scheduler_last_result = get_setting(conn, "scheduler_last_result")
     finally:
         conn.close()
+
+    # スケジューラのステータス表示
+    result_label = {"success": "成功", "failure": "失敗", "skipped": "スキップ"}.get(scheduler_last_result or "", "")
+    scheduler_status = "まだ実行されていません"
+    if scheduler_last_run:
+        with contextlib.suppress(ValueError):
+            last_run_disp = datetime.fromisoformat(scheduler_last_run).strftime("%Y-%m-%d %H:%M")
+            scheduler_status = f"最終実行: {last_run_disp}" + (f" — {result_label}" if result_label else "")
+    if scheduler_enabled:
+        next_run = _next_scheduled_run(datetime.now(), scheduler_time)
+        scheduler_status += f" ／ 次回予定: {next_run.strftime('%Y-%m-%d %H:%M')}"
+    else:
+        scheduler_status += " ／ 自動取得: オフ"
     env_key = os.environ.get("GEMINI_API_KEY", "")
     # 表示用マスク
     if env_key:
@@ -4851,6 +4868,27 @@ def _build_settings_html(db_path: str, saved: str | None = None) -> str:
           </label>
         </div>
         <div class="hint">締め日が土日祝日に当たる場合の調整方法を選択します。</div>
+      </div>
+      <button type="submit" class="btn">保存</button>
+    </form>
+  </div>
+  <div class="card">
+    <h2>自動データ取得</h2>
+    <div class="status">{scheduler_status}</div>
+    <p style="font-size:0.85rem;color:#636e72;margin-bottom:12px">
+      サーバー起動中、毎日指定した時刻にデータを自動取得します。停止していた場合は起動後に追いつき実行されます。
+    </p>
+    <form method="POST" action="/settings">
+      <input type="hidden" name="setting_type" value="scheduler">
+      <div class="field">
+        <label style="font-weight:normal;font-size:0.9rem;display:flex;align-items:center;gap:6px">
+          <input type="checkbox" name="scheduler_enabled" value="1" style="width:auto"{" checked" if scheduler_enabled else ""}> 自動取得を有効にする
+        </label>
+      </div>
+      <div class="field">
+        <label>実行時刻</label>
+        <input type="time" name="scheduler_time" value="{scheduler_time}" style="width:auto">
+        <div class="hint">デフォルトは毎日 7:00 です。設定はサーバー再起動なしで反映されます。</div>
       </div>
       <button type="submit" class="btn">保存</button>
     </form>
@@ -6950,6 +6988,21 @@ class Handler(BaseHTTPRequestHandler):
                     save_setting(conn, "closing_day", str(closing_day_val))
                     save_setting(conn, "closing_day_holiday", holiday_mode_val)
                     logger.info("締め日更新: %d日 (祝日: %s)", closing_day_val, holiday_mode_val)
+                finally:
+                    conn.close()
+            elif setting_type == "scheduler":
+                # 自動データ取得設定
+                enabled_val = "1" if post_params.get("scheduler_enabled") else "0"
+                time_str = post_params.get("scheduler_time", [_SCHEDULER_DEFAULT_TIME])[0].strip()
+                try:
+                    datetime.strptime(time_str, "%H:%M")
+                except ValueError:
+                    time_str = _SCHEDULER_DEFAULT_TIME
+                conn = get_connection(self.db_path)
+                try:
+                    save_setting(conn, "scheduler_enabled", enabled_val)
+                    save_setting(conn, "scheduler_time", time_str)
+                    logger.info("スケジューラ設定更新: enabled=%s, time=%s", enabled_val, time_str)
                 finally:
                     conn.close()
             else:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -106,7 +106,7 @@ class TestSchedulerTick:
     NOW = datetime(2026, 6, 10, 7, 5)
 
     def _stub_worker(self, monkeypatch, db_path: str, success: bool = True):
-        """_bg_worker を呼び出し記録付きのスタブに差し替える。"""
+        """_run_update_locked を呼び出し記録付きのスタブに差し替える。"""
         calls = []
 
         def fake_worker(path):
@@ -114,7 +114,7 @@ class TestSchedulerTick:
             if success:
                 _set(db_path, "last_fetch_at", self.NOW.isoformat())
 
-        monkeypatch.setattr(server, "_bg_worker", fake_worker)
+        monkeypatch.setattr(server, "_run_update_locked", fake_worker)
         return calls
 
     def test_disabled_does_nothing(self, monkeypatch, db_path):
@@ -164,16 +164,18 @@ class TestSchedulerTick:
         assert _get(db_path, "scheduler_last_result") == "skipped"
 
     def test_carry_over_while_startup_update_running(self, monkeypatch, db_path):
-        # 起動時更新の実行中は試行時刻を保存せず持ち越す
+        # 起動時更新がロックを保持中は試行時刻を保存せず持ち越す
         # → 起動時更新が失敗しても当日の再取得機会を失わない
         _set(db_path, "last_fetch_at", (self.NOW - timedelta(days=1)).isoformat())
         calls = self._stub_worker(monkeypatch, db_path, success=True)
-        monkeypatch.setitem(server._update_state, "running", True)
-        _scheduler_tick(db_path, now=self.NOW)
+        server._update_lock.acquire()
+        try:
+            _scheduler_tick(db_path, now=self.NOW)
+        finally:
+            server._update_lock.release()
         assert calls == []
         assert _get(db_path, "scheduler_last_run_at") is None  # 持ち越し
         # 起動時更新が終了（失敗で last_fetch_at は古いまま）→ 次の tick で実行される
-        monkeypatch.setitem(server._update_state, "running", False)
         _scheduler_tick(db_path, now=datetime(2026, 6, 10, 7, 6))
         assert calls == [db_path]
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,10 +1,16 @@
 """サーバー内蔵スケジューラのテスト — 時刻判定・重複スキップ・設定保存を検証。"""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
+import pytest
+
+import src.web.server as server
+from src.db.repository import get_setting, save_setting
+from src.db.schema import init_db
 from src.web.server import (
     _next_scheduled_run,
     _parse_scheduler_time,
+    _scheduler_tick,
     _should_run_scheduled,
 )
 
@@ -70,3 +76,95 @@ class TestNextScheduledRun:
     def test_tomorrow_if_just_after(self):
         now = datetime(2026, 6, 10, 8, 30)
         assert _next_scheduled_run(now, "07:00") == datetime(2026, 6, 11, 7, 0)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    p = tmp_path / "scheduler_test.db"
+    conn = init_db(str(p))
+    conn.close()
+    return str(p)
+
+
+def _get(db_path: str, key: str) -> str | None:
+    conn = init_db(db_path)
+    try:
+        return get_setting(conn, key)
+    finally:
+        conn.close()
+
+
+def _set(db_path: str, key: str, value: str) -> None:
+    conn = init_db(db_path)
+    try:
+        save_setting(conn, key, value)
+    finally:
+        conn.close()
+
+
+class TestSchedulerTick:
+    NOW = datetime(2026, 6, 10, 7, 5)
+
+    def _stub_worker(self, monkeypatch, db_path: str, success: bool = True):
+        """_bg_worker を呼び出し記録付きのスタブに差し替える。"""
+        calls = []
+
+        def fake_worker(path):
+            calls.append(path)
+            if success:
+                _set(db_path, "last_fetch_at", self.NOW.isoformat())
+
+        monkeypatch.setattr(server, "_bg_worker", fake_worker)
+        return calls
+
+    def test_disabled_does_nothing(self, monkeypatch, db_path):
+        _set(db_path, "scheduler_enabled", "0")
+        calls = self._stub_worker(monkeypatch, db_path)
+        _scheduler_tick(db_path, now=self.NOW)
+        assert calls == []
+        assert _get(db_path, "scheduler_last_run_at") is None
+
+    def test_before_time_does_nothing(self, monkeypatch, db_path):
+        calls = self._stub_worker(monkeypatch, db_path)
+        _scheduler_tick(db_path, now=datetime(2026, 6, 10, 6, 0))
+        assert calls == []
+        assert _get(db_path, "scheduler_last_run_at") is None
+
+    def test_runs_and_records_success(self, monkeypatch, db_path):
+        _set(db_path, "last_fetch_at", (self.NOW - timedelta(days=1)).isoformat())
+        calls = self._stub_worker(monkeypatch, db_path, success=True)
+        _scheduler_tick(db_path, now=self.NOW)
+        assert calls == [db_path]
+        assert _get(db_path, "scheduler_last_run_at") == self.NOW.isoformat()
+        assert _get(db_path, "scheduler_last_result") == "success"
+
+    def test_records_failure_when_fetch_not_updated(self, monkeypatch, db_path):
+        _set(db_path, "last_fetch_at", (self.NOW - timedelta(days=1)).isoformat())
+        calls = self._stub_worker(monkeypatch, db_path, success=False)
+        _scheduler_tick(db_path, now=self.NOW)
+        assert calls == [db_path]
+        assert _get(db_path, "scheduler_last_result") == "failure"
+
+    def test_no_duplicate_run_same_day(self, monkeypatch, db_path):
+        _set(db_path, "last_fetch_at", (self.NOW - timedelta(days=1)).isoformat())
+        calls = self._stub_worker(monkeypatch, db_path, success=True)
+        _scheduler_tick(db_path, now=self.NOW)
+        _scheduler_tick(db_path, now=datetime(2026, 6, 10, 8, 0))
+        assert calls == [db_path]  # 2回目は重複スキップで呼ばれない
+
+    def test_skipped_when_data_fresh(self, monkeypatch, db_path):
+        # 起動時更新が直前（10分前）に成功済み → 試行は記録されるが取得はスキップ
+        _set(db_path, "last_fetch_at", (self.NOW - timedelta(minutes=10)).isoformat())
+        calls = self._stub_worker(monkeypatch, db_path)
+        _scheduler_tick(db_path, now=self.NOW)
+        assert calls == []
+        assert _get(db_path, "scheduler_last_result") == "skipped"
+
+    def test_custom_time_setting(self, monkeypatch, db_path):
+        _set(db_path, "scheduler_time", "21:30")
+        _set(db_path, "last_fetch_at", (self.NOW - timedelta(days=1)).isoformat())
+        calls = self._stub_worker(monkeypatch, db_path)
+        _scheduler_tick(db_path, now=datetime(2026, 6, 10, 21, 29))
+        assert calls == []
+        _scheduler_tick(db_path, now=datetime(2026, 6, 10, 21, 31))
+        assert calls == [db_path]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -154,11 +154,28 @@ class TestSchedulerTick:
 
     def test_skipped_when_data_fresh(self, monkeypatch, db_path):
         # 起動時更新が直前（10分前）に成功済み → 試行は記録されるが取得はスキップ
+        # _should_update は実時刻を参照するためスタブで「データが新しい」状態を固定する
         _set(db_path, "last_fetch_at", (self.NOW - timedelta(minutes=10)).isoformat())
         calls = self._stub_worker(monkeypatch, db_path)
+        monkeypatch.setattr(server, "_should_update", lambda *a, **kw: False)
         _scheduler_tick(db_path, now=self.NOW)
         assert calls == []
+        assert _get(db_path, "scheduler_last_run_at") == self.NOW.isoformat()
         assert _get(db_path, "scheduler_last_result") == "skipped"
+
+    def test_carry_over_while_startup_update_running(self, monkeypatch, db_path):
+        # 起動時更新の実行中は試行時刻を保存せず持ち越す
+        # → 起動時更新が失敗しても当日の再取得機会を失わない
+        _set(db_path, "last_fetch_at", (self.NOW - timedelta(days=1)).isoformat())
+        calls = self._stub_worker(monkeypatch, db_path, success=True)
+        monkeypatch.setitem(server._update_state, "running", True)
+        _scheduler_tick(db_path, now=self.NOW)
+        assert calls == []
+        assert _get(db_path, "scheduler_last_run_at") is None  # 持ち越し
+        # 起動時更新が終了（失敗で last_fetch_at は古いまま）→ 次の tick で実行される
+        monkeypatch.setitem(server._update_state, "running", False)
+        _scheduler_tick(db_path, now=datetime(2026, 6, 10, 7, 6))
+        assert calls == [db_path]
 
     def test_custom_time_setting(self, monkeypatch, db_path):
         _set(db_path, "scheduler_time", "21:30")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,72 @@
+"""サーバー内蔵スケジューラのテスト — 時刻判定・重複スキップ・設定保存を検証。"""
+
+from datetime import datetime
+
+from src.web.server import (
+    _next_scheduled_run,
+    _parse_scheduler_time,
+    _should_run_scheduled,
+)
+
+
+class TestParseSchedulerTime:
+    def test_valid(self):
+        assert _parse_scheduler_time("07:00") == (7, 0)
+        assert _parse_scheduler_time("23:45") == (23, 45)
+        assert _parse_scheduler_time("0:05") == (0, 5)
+
+    def test_invalid_falls_back_to_default(self):
+        assert _parse_scheduler_time("25:00") == (7, 0)
+        assert _parse_scheduler_time("abc") == (7, 0)
+        assert _parse_scheduler_time("") == (7, 0)
+        assert _parse_scheduler_time(None) == (7, 0)
+
+
+class TestShouldRunScheduled:
+    def test_before_scheduled_time(self):
+        now = datetime(2026, 6, 10, 6, 59)
+        assert _should_run_scheduled(now, "07:00", None) is False
+
+    def test_first_run(self):
+        now = datetime(2026, 6, 10, 7, 0)
+        assert _should_run_scheduled(now, "07:00", None) is True
+
+    def test_already_ran_today(self):
+        now = datetime(2026, 6, 10, 8, 0)
+        last = datetime(2026, 6, 10, 7, 1)
+        assert _should_run_scheduled(now, "07:00", last) is False
+
+    def test_next_day(self):
+        now = datetime(2026, 6, 11, 7, 0)
+        last = datetime(2026, 6, 10, 7, 1)
+        assert _should_run_scheduled(now, "07:00", last) is True
+
+    def test_catch_up_after_downtime(self):
+        # サーバーが 7:00 に停止していた → 起動後の判定で追いつき実行
+        now = datetime(2026, 6, 10, 12, 34)
+        last = datetime(2026, 6, 9, 7, 0)
+        assert _should_run_scheduled(now, "07:00", last) is True
+
+    def test_no_retry_after_failure(self):
+        # 失敗しても試行時刻が記録される → 翌日まで再試行しない
+        now = datetime(2026, 6, 10, 7, 5)
+        last = datetime(2026, 6, 10, 7, 0)
+        assert _should_run_scheduled(now, "07:00", last) is False
+
+    def test_invalid_time_uses_default(self):
+        now = datetime(2026, 6, 10, 7, 30)
+        assert _should_run_scheduled(now, "invalid", None) is True
+
+
+class TestNextScheduledRun:
+    def test_today_if_future(self):
+        now = datetime(2026, 6, 10, 6, 0)
+        assert _next_scheduled_run(now, "07:00") == datetime(2026, 6, 10, 7, 0)
+
+    def test_tomorrow_if_passed(self):
+        now = datetime(2026, 6, 10, 7, 0)
+        assert _next_scheduled_run(now, "07:00") == datetime(2026, 6, 11, 7, 0)
+
+    def test_tomorrow_if_just_after(self):
+        now = datetime(2026, 6, 10, 8, 30)
+        assert _next_scheduled_run(now, "07:00") == datetime(2026, 6, 11, 7, 0)

--- a/tests/test_server_html.py
+++ b/tests/test_server_html.py
@@ -749,6 +749,30 @@ class TestSchedulerSetting:
         html = _build_settings_html(str(db_path), saved=False)
         assert "自動取得: オフ" in html
 
+    def test_settings_shows_stopped_when_skip_update(self, tmp_path):
+        # --demo / --skip-update 起動時はスケジューラが動いていないので次回予定を出さない
+        db_path = tmp_path / "scheduler_skip_test.db"
+        conn = init_db(str(db_path))
+        conn.close()
+        html = _build_settings_html(str(db_path), saved=False, skip_update=True)
+        assert "自動取得: 停止中" in html
+        assert "次回予定" not in html
+
+    def test_saved_msg_scheduler_has_no_ai_text(self, tmp_path):
+        db_path = tmp_path / "saved_msg_test.db"
+        conn = init_db(str(db_path))
+        conn.close()
+        html = _build_settings_html(str(db_path), saved="scheduler")
+        assert "設定を保存しました。" in html
+        assert "AIコメントをバックグラウンドで生成中" not in html
+
+    def test_saved_msg_gemini_has_ai_text(self, tmp_path):
+        db_path = tmp_path / "saved_msg_gemini_test.db"
+        conn = init_db(str(db_path))
+        conn.close()
+        html = _build_settings_html(str(db_path), saved="gemini")
+        assert "AIコメントをバックグラウンドで生成中" in html
+
 
 class TestDashboardFetchStatus:
     """ダッシュボードに最終取得日時と次回予定が表示される。"""

--- a/tests/test_server_html.py
+++ b/tests/test_server_html.py
@@ -8,6 +8,7 @@ import re
 
 import pytest
 
+from src.db.repository import save_setting
 from src.db.schema import init_db
 from src.web.server import (
     Handler,
@@ -701,6 +702,52 @@ class TestClosingDaySetting:
         assert "設定日前の平日" in html
         assert "設定日後の平日" in html
         assert 'name="holiday_mode"' in html
+
+
+# --- スケジューラ設定 (#58) ---
+
+
+class TestSchedulerSetting:
+    """自動データ取得の設定カードが設定ページに表示される。"""
+
+    def test_settings_has_scheduler_section(self, tmp_path):
+        html = _build_settings_html_for_test(tmp_path)
+        assert "自動データ取得" in html
+        assert 'value="scheduler"' in html  # setting_type hidden
+
+    def test_settings_has_time_input_with_default(self, tmp_path):
+        html = _build_settings_html_for_test(tmp_path)
+        assert 'type="time"' in html
+        assert 'name="scheduler_time"' in html
+        assert 'value="07:00"' in html
+
+    def test_settings_has_enabled_checkbox(self, tmp_path):
+        html = _build_settings_html_for_test(tmp_path)
+        assert 'name="scheduler_enabled"' in html
+        assert "自動取得を有効にする" in html
+
+    def test_settings_shows_next_run(self, tmp_path):
+        # デフォルト有効 → 次回予定が表示される
+        html = _build_settings_html_for_test(tmp_path)
+        assert "次回予定" in html
+
+    def test_settings_shows_last_result(self, tmp_path):
+        db_path = tmp_path / "scheduler_settings_test.db"
+        conn = init_db(str(db_path))
+        save_setting(conn, "scheduler_last_run_at", "2026-06-10T07:00:00")
+        save_setting(conn, "scheduler_last_result", "success")
+        conn.close()
+        html = _build_settings_html(str(db_path), saved=False)
+        assert "最終実行: 2026-06-10 07:00" in html
+        assert "成功" in html
+
+    def test_settings_shows_off_when_disabled(self, tmp_path):
+        db_path = tmp_path / "scheduler_off_test.db"
+        conn = init_db(str(db_path))
+        save_setting(conn, "scheduler_enabled", "0")
+        conn.close()
+        html = _build_settings_html(str(db_path), saved=False)
+        assert "自動取得: オフ" in html
 
 
 # --- Favicon (#37) ---

--- a/tests/test_server_html.py
+++ b/tests/test_server_html.py
@@ -750,6 +750,28 @@ class TestSchedulerSetting:
         assert "自動取得: オフ" in html
 
 
+class TestDashboardFetchStatus:
+    """ダッシュボードに最終取得日時と次回予定が表示される。"""
+
+    def test_shows_last_fetch_and_next_run(self):
+        data = _demo_data()
+        html = _build_html(data, [data["date"]], last_fetch_at="2026-06-10 07:01", next_run_at="06-11 07:00")
+        assert "最終取得: 2026-06-10 07:01" in html
+        assert "次回自動取得: 06-11 07:00" in html
+
+    def test_hidden_when_not_provided(self):
+        data = _demo_data()
+        html = _build_html(data, [data["date"]])
+        assert "最終取得" not in html
+        assert "次回自動取得" not in html
+
+    def test_last_fetch_only(self):
+        data = _demo_data()
+        html = _build_html(data, [data["date"]], last_fetch_at="2026-06-10 07:01")
+        assert "最終取得: 2026-06-10 07:01" in html
+        assert "次回自動取得" not in html
+
+
 # --- Favicon (#37) ---
 
 


### PR DESCRIPTION
## 概要
Webサーバーにスケジューラを組み込み、毎日指定時刻（デフォルト 7:00）に `daily.py` を自動実行する。サーバーを起動しておくだけでデータが蓄積される。Closes に依らず、人間確認後にマージ → Issue #58 をクローズ。

## 変更内容
- **時刻判定の純粋関数**: `_parse_scheduler_time` / `_should_run_scheduled` / `_next_scheduled_run`。経過時間ではなく「前回実行 < 当日の予定時刻」のスロット比較で重複実行を防止（drift なし）。サーバー停止中に予定時刻を過ぎた場合は起動後に追いつき実行
- **スケジューラスレッド**: `_scheduler_loop`（毎分 tick の daemon スレッド）を `main()` で起動。`--demo` / `--skip-update` 時は起動しない。設定は毎 tick で DB から読み直すため再起動なしで反映
- **失敗時の暴走防止**: 試行時刻 `scheduler_last_run_at` を実行前に保存し、失敗時の毎分リトライを防ぐ（再試行は翌日）。起動時更新の実行中は保存せず持ち越し、起動時更新が失敗しても当日の取得機会を失わない
- **排他制御**: `_update_lock` で起動時更新とスケジューラの同時実行を1本に抑制
- **設定ページ**: 「自動データ取得」カード（有効/無効チェックボックス + time input、最終実行・結果・次回予定の表示）
- **ダッシュボード**: date-picker 下に「最終取得 ／ 次回自動取得」を表示
- **settings キー**: `scheduler_enabled` / `scheduler_time` / `scheduler_last_run_at` / `scheduler_last_result`（専用テーブルは追加せず）

## 自動テスト（pytest で検証済み — 307 passed）
- [x] スケジューラの時刻判定ロジック（時刻前/初回/当日実行済み/翌日/追いつき/不正値フォールバック）
- [x] 重複実行スキップの判定（同日2回目は実行されない、失敗後の毎分リトライ防止、起動時更新中の持ち越し）
- [x] 設定の保存・読み込み（`_scheduler_tick` の試行時刻・結果保存、カスタム時刻設定）
- [x] 設定ページ HTML（time input、チェックボックス、最終実行・次回予定・オフ表示）
- [x] ダッシュボード HTML（最終取得・次回予定の表示/非表示）

## 人間が確認すること
- [ ] サーバー起動後、設定した時刻（数分後に設定して試す）にデータ取得が自動実行されるか
- [ ] 設定ページで実行時刻を変更でき、再起動なしで次回予定に反映されるか
- [ ] サーバー再起動後も設定が維持されるか
- [ ] ダッシュボードの「最終取得 ／ 次回自動取得」表示が自然か（モバイル含む）
- [ ] `--demo` で設定カード・ダッシュボード表示が崩れていないか

Refs #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)