### PR TITLE
OS起動時のサーバー自動起動 (systemd / タスクスケジューラ) (#59)

### DIFF
--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -1,0 +1,54 @@
+# 自動起動の設定 (#59)
+
+OS 起動 / ログイン時にダッシュボード (`python -m src.web.server`, `http://localhost:8080`) を
+自動起動する手順。環境ごとに使う仕組みが違う。
+
+## Linux（systemd）
+
+```bash
+bash install.sh --autostart
+```
+
+`scripts/mf-tracker.service` をテンプレートに、絶対パスを埋めた systemd ユーザーサービスを
+`~/.config/systemd/user/mf-tracker.service` に生成し、`systemctl --user enable --now` まで実行する。
+
+- 状態: `systemctl --user status mf-tracker`
+- 解除: `systemctl --user disable --now mf-tracker`
+- ログインシェルを開かずに常駐させたい場合: `loginctl enable-linger $USER`
+
+## WSL2（systemd=true）+ Windows ログオン
+
+WSL 内とWindows側の2層で設定する。
+
+1. **WSL 内のサービス**（上の Linux 手順と同じ）:
+   ```bash
+   bash install.sh --autostart
+   loginctl enable-linger "$USER"   # WSL ではシェル無し常駐に必要
+   ```
+   `/etc/wsl.conf` に `[boot] systemd=true` が必要。
+
+2. **Windows ログオン → WSL 起動**:
+   ```bash
+   bash scripts/register-wsl-startup.sh
+   ```
+   Windows のスタートアップフォルダに VBS ランチャ（管理者権限不要）を置き、ログオン時に
+   コンソール非表示で `wsl.exe -d <distro> -e true` を実行する。WSL が起動すれば systemd と
+   linger 済みサービスが立ち上がる。解除は `bash scripts/register-wsl-startup.sh --unregister`。
+
+連鎖: Windows ログオン → VBS(非表示) → WSL 起動 → systemd → mf-tracker → `http://localhost:8080`
+
+> ネイティブ Windows ではなく WSL でサーバーを動かす場合はこちらを使う。
+> `register-task.ps1`（下記）は WSL を経由しないネイティブ Windows 向け。
+
+## Windows（ネイティブ Python / タスクスケジューラ）
+
+WSL を使わず Windows 上で直接サーバーを動かす場合:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File install.ps1 -AutoStart
+# または個別に:
+powershell -ExecutionPolicy Bypass -File scripts\register-task.ps1
+```
+
+`pythonw.exe` でコンソール非表示のログオン時タスク `MFTrackerDashboard` を登録する。
+解除は `powershell -ExecutionPolicy Bypass -File scripts\register-task.ps1 -Unregister`。

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,10 @@
 # MoneyForward ME 資産トラッカー — ワンコマンドインストール (Windows PowerShell)
-# Usage: powershell -ExecutionPolicy Bypass -File install.ps1
+# Usage: powershell -ExecutionPolicy Bypass -File install.ps1 [-AutoStart]
+#   -AutoStart : ログオン時にダッシュボードを自動起動するタスクを登録
+
+param(
+    [switch]$AutoStart
+)
 
 $ErrorActionPreference = "Stop"
 
@@ -91,6 +96,13 @@ Write-Info "Playwright Chromium をインストール中..."
 & $venvPython -m playwright install chromium
 Write-Ok "Playwright Chromium インストール完了"
 
+# --- 自動起動の登録 ---------------------------------------------------------
+
+if ($AutoStart) {
+    Write-Info "ログオン時自動起動タスクを登録中..."
+    & powershell -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot "scripts\register-task.ps1")
+}
+
 # --- 完了 -------------------------------------------------------------------
 
 Write-Host ""
@@ -112,3 +124,8 @@ Write-Host ""
 Write-Host "  デモモードで試す場合:"
 Write-Host "     python -m src.web.server --demo"
 Write-Host ""
+if (-not $AutoStart) {
+    Write-Host "  ログオン時に自動起動させる場合:"
+    Write-Host "     powershell -ExecutionPolicy Bypass -File install.ps1 -AutoStart"
+    Write-Host ""
+}

--- a/install.sh
+++ b/install.sh
@@ -2,10 +2,26 @@
 set -euo pipefail
 
 # MoneyForward ME 資産トラッカー — ワンコマンドインストール
-# Usage: bash install.sh
+# Usage: bash install.sh [--autostart]
+#   --autostart : ログイン時にダッシュボードを自動起動する systemd ユーザーサービスを登録
 
 PYTHON_MIN="3.11"
 VENV_DIR=".venv"
+AUTOSTART=0
+
+# --- 引数パース -------------------------------------------------------------
+
+for arg in "$@"; do
+    case "$arg" in
+        --autostart) AUTOSTART=1 ;;
+        -h|--help)
+            echo "Usage: bash install.sh [--autostart]"
+            echo "  --autostart : ログイン時自動起動の systemd ユーザーサービスを登録"
+            exit 0
+            ;;
+        *) printf '不明な引数: %s\n' "$arg" >&2; exit 1 ;;
+    esac
+done
 
 # --- ヘルパー関数 -----------------------------------------------------------
 
@@ -13,6 +29,38 @@ info()  { printf '\033[1;34m[INFO]\033[0m  %s\n' "$*"; }
 ok()    { printf '\033[1;32m[OK]\033[0m    %s\n' "$*"; }
 warn()  { printf '\033[1;33m[WARN]\033[0m  %s\n' "$*"; }
 error() { printf '\033[1;31m[ERROR]\033[0m %s\n' "$*"; exit 1; }
+
+# --- 自動起動（systemd ユーザーサービス）------------------------------------
+
+setup_autostart() {
+    local template="scripts/mf-tracker.service"
+    [ -f "$template" ] || { warn "テンプレートが見つかりません: $template — 自動起動の登録をスキップ"; return; }
+
+    if ! command -v systemctl &>/dev/null; then
+        warn "systemctl が見つかりません。自動起動の登録をスキップします（systemd 環境でのみ対応）。"
+        return
+    fi
+
+    local workdir python_bin unit_dir
+    workdir="$(pwd)"
+    python_bin="$workdir/$VENV_DIR/bin/python"
+    unit_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+
+    info "systemd ユーザーサービスを登録中..."
+    mkdir -p "$unit_dir"
+    sed -e "s|__WORKDIR__|$workdir|g" -e "s|__PYTHON__|$python_bin|g" \
+        "$template" > "$unit_dir/mf-tracker.service"
+
+    systemctl --user daemon-reload
+    if systemctl --user enable --now mf-tracker.service 2>/dev/null; then
+        ok "自動起動を有効化しました (systemctl --user enable mf-tracker)"
+    else
+        warn "サービスの有効化に失敗しました。ユニットは生成済みです:
+  $unit_dir/mf-tracker.service
+  手動で有効化: systemctl --user enable --now mf-tracker.service
+  （リモート/SSH では 'loginctl enable-linger \$USER' が必要な場合があります）"
+    fi
+}
 
 # バージョン文字列を比較 (a >= b なら 0)
 # macOS の BSD sort は -V 未対応のため数値比較で実装
@@ -101,6 +149,12 @@ else
     sudo $VENV_DIR/bin/python -m playwright install-deps chromium"
 fi
 
+# --- 自動起動の登録 ---------------------------------------------------------
+
+if [ "$AUTOSTART" = "1" ]; then
+    setup_autostart
+fi
+
 # --- 完了 -------------------------------------------------------------------
 
 echo ""
@@ -122,3 +176,8 @@ echo ""
 echo "  デモモードで試す場合:"
 echo "     python -m src.web.server --demo"
 echo ""
+if [ "$AUTOSTART" != "1" ]; then
+    echo "  ログイン時に自動起動させる場合:"
+    echo "     bash install.sh --autostart"
+    echo ""
+fi

--- a/scripts/mf-tracker.service
+++ b/scripts/mf-tracker.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=MoneyForward ME Asset Tracker dashboard
+# ネットワークが上がってから起動（ユーザーサービスでは無害な順序指定）
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# 以下のパスは install.sh --autostart が絶対パスへ置換する
+WorkingDirectory=__WORKDIR__
+ExecStart=__PYTHON__ -m src.web.server
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/scripts/register-task.ps1
+++ b/scripts/register-task.ps1
@@ -1,0 +1,70 @@
+# MoneyForward ME 資産トラッカー — ログオン時自動起動タスクの登録 (Windows)
+#
+# Usage:
+#   登録:   powershell -ExecutionPolicy Bypass -File scripts\register-task.ps1
+#   解除:   powershell -ExecutionPolicy Bypass -File scripts\register-task.ps1 -Unregister
+#
+# ログオン時にダッシュボードをバックグラウンド（コンソールウィンドウ非表示）で起動する。
+# 非表示実行のため pythonw.exe を使う。
+
+param(
+    [switch]$Unregister
+)
+
+$ErrorActionPreference = "Stop"
+
+$TaskName = "MFTrackerDashboard"
+
+function Write-Info { param([string]$Message) Write-Host "[INFO]  $Message" -ForegroundColor Cyan }
+function Write-Ok   { param([string]$Message) Write-Host "[OK]    $Message" -ForegroundColor Green }
+function Write-Warn { param([string]$Message) Write-Host "[WARN]  $Message" -ForegroundColor Yellow }
+function Write-Err  { param([string]$Message) Write-Host "[ERROR] $Message" -ForegroundColor Red; exit 1 }
+
+# --- 解除 -------------------------------------------------------------------
+
+if ($Unregister) {
+    if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+        Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+        Write-Ok "自動起動タスクを解除しました: $TaskName"
+    } else {
+        Write-Info "自動起動タスクは登録されていません: $TaskName"
+    }
+    return
+}
+
+# --- パス解決 ---------------------------------------------------------------
+# このスクリプトは scripts\ にあるので、リポジトリルートは1つ上。
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$pythonw = Join-Path $repoRoot ".venv\Scripts\pythonw.exe"
+
+if (-not (Test-Path $pythonw)) {
+    Write-Err @"
+仮想環境の pythonw.exe が見つかりません: $pythonw
+  先に install.ps1 を実行して仮想環境を作成してください。
+"@
+}
+
+# --- タスク登録 -------------------------------------------------------------
+
+Write-Info "ログオン時自動起動タスクを登録中: $TaskName"
+
+$action = New-ScheduledTaskAction -Execute $pythonw -Argument "-m src.web.server" -WorkingDirectory $repoRoot
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
+
+Register-ScheduledTask `
+    -TaskName $TaskName `
+    -Action $action `
+    -Trigger $trigger `
+    -Settings $settings `
+    -Description "MoneyForward ME 資産トラッカー ダッシュボードをログオン時に起動" `
+    -Force | Out-Null
+
+Write-Ok "登録完了: $TaskName"
+Write-Host ""
+Write-Host "  次回ログオンから自動起動します。すぐ試す場合は手動実行:"
+Write-Host "    Start-ScheduledTask -TaskName $TaskName"
+Write-Host "  解除する場合:"
+Write-Host "    powershell -ExecutionPolicy Bypass -File scripts\register-task.ps1 -Unregister"
+Write-Host ""

--- a/scripts/register-wsl-startup.sh
+++ b/scripts/register-wsl-startup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# MoneyForward ME 資産トラッカー — WSL 運用時の Windows ログオン自動起動
+#
+# 用途:
+#   WSL2 + systemd でダッシュボードを動かしている場合に、Windows ログオン時へ
+#   WSL ディストロを自動起動させる。WSL 内のサービス自体は
+#   `bash install.sh --autostart`（systemd ユーザーサービス + linger）で登録しておくこと。
+#   このスクリプトは「Windows ログオン → WSL 起動」の一手だけを担う。
+#
+# 仕組み:
+#   Windows のスタートアップフォルダに VBS ランチャを置く（管理者権限不要）。
+#   ログオン時にコンソール非表示で `wsl.exe -d <distro> -e true` を実行し、
+#   systemd(=PID1) と linger 済みユーザーサービスが立ち上がる。
+#
+# Usage:
+#   bash scripts/register-wsl-startup.sh              # 登録
+#   bash scripts/register-wsl-startup.sh --unregister # 解除
+
+UNREGISTER=0
+[ "${1:-}" = "--unregister" ] && UNREGISTER=1
+
+info()  { printf '\033[1;34m[INFO]\033[0m  %s\n' "$*"; }
+ok()    { printf '\033[1;32m[OK]\033[0m    %s\n' "$*"; }
+error() { printf '\033[1;31m[ERROR]\033[0m %s\n' "$*"; exit 1; }
+
+# WSL 上でのみ意味がある
+grep -qiE "(microsoft|wsl)" /proc/version 2>/dev/null || error "WSL 環境ではありません。このスクリプトは WSL 専用です。"
+
+DISTRO="${WSL_DISTRO_NAME:-Ubuntu}"
+
+# Windows のスタートアップフォルダを解決
+appdata_win="$(cmd.exe /c 'echo %APPDATA%' 2>/dev/null | tr -d '\r')"
+[ -n "$appdata_win" ] || error "%APPDATA% を取得できませんでした。"
+startup="$(wslpath "$appdata_win")/Microsoft/Windows/Start Menu/Programs/Startup"
+[ -d "$startup" ] || error "スタートアップフォルダが見つかりません: $startup"
+
+vbs="$startup/start-mf-tracker-wsl.vbs"
+
+if [ "$UNREGISTER" = "1" ]; then
+    if [ -f "$vbs" ]; then
+        rm -f "$vbs"
+        ok "Windows ログオン自動起動を解除しました: $vbs"
+    else
+        info "登録されていません: $vbs"
+    fi
+    exit 0
+fi
+
+# VBS を CRLF で書き出す（Windows スクリプト）。ウィンドウ非表示(0)・待たない(False)。
+printf 'Set sh = CreateObject("WScript.Shell")\r\nsh.Run "wsl.exe -d %s -e true", 0, False\r\n' "$DISTRO" > "$vbs"
+ok "Windows ログオン時に WSL($DISTRO) を起動するランチャを登録しました:"
+echo "    $vbs"
+echo ""
+echo "  次回 Windows ログオンから有効。解除する場合:"
+echo "    bash scripts/register-wsl-startup.sh --unregister"

--- a/tests/test_systemd_unit.py
+++ b/tests/test_systemd_unit.py
@@ -1,0 +1,74 @@
+"""scripts/mf-tracker.service の構文・構造を検証するテスト。
+
+systemd 本体を必要とせず、ユニットファイルを INI として解析して
+必須セクション・キー・プレースホルダの存在を確認する。
+実際に reboot 後に起動するかは人間が確認する（Issue #59 のチェックリスト）。
+"""
+
+from configparser import RawConfigParser
+from pathlib import Path
+
+import pytest
+
+UNIT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "mf-tracker.service"
+
+
+def _parse_unit() -> RawConfigParser:
+    # systemd ユニットは INI 形式。% を含む値での補間エラーを避けるため Raw を使う。
+    parser = RawConfigParser()
+    parser.optionxform = str  # キーの大文字小文字を保持（systemd は case-sensitive）
+    parser.read_string(UNIT_PATH.read_text(encoding="utf-8"))
+    return parser
+
+
+def test_unit_file_exists() -> None:
+    assert UNIT_PATH.is_file(), f"ユニットテンプレートがない: {UNIT_PATH}"
+
+
+def test_required_sections() -> None:
+    parser = _parse_unit()
+    for section in ("Unit", "Service", "Install"):
+        assert parser.has_section(section), f"[{section}] セクションがない"
+
+
+def test_service_keys() -> None:
+    parser = _parse_unit()
+    assert parser.get("Service", "Type") == "simple"
+    assert parser.has_option("Service", "WorkingDirectory")
+    assert parser.has_option("Service", "ExecStart")
+    # サーバーをモジュール起動していること
+    assert "-m src.web.server" in parser.get("Service", "ExecStart")
+
+
+def test_install_wantedby() -> None:
+    parser = _parse_unit()
+    # ユーザーサービスとして自動起動するには default.target に紐づける
+    assert parser.get("Install", "WantedBy") == "default.target"
+
+
+def test_placeholders_present() -> None:
+    text = UNIT_PATH.read_text(encoding="utf-8")
+    # install.sh が絶対パスへ置換するためのトークン
+    assert "__WORKDIR__" in text
+    assert "__PYTHON__" in text
+
+
+def test_substituted_unit_has_no_placeholders() -> None:
+    # install.sh の sed 置換を模して、置換後に未解決トークンが残らないことを確認
+    text = UNIT_PATH.read_text(encoding="utf-8")
+    substituted = text.replace("__WORKDIR__", "/home/user/asset-dashboard").replace(
+        "__PYTHON__", "/home/user/asset-dashboard/.venv/bin/python"
+    )
+    assert "__WORKDIR__" not in substituted
+    assert "__PYTHON__" not in substituted
+
+    parser = RawConfigParser()
+    parser.optionxform = str
+    parser.read_string(substituted)
+    exec_start = parser.get("Service", "ExecStart")
+    assert exec_start.startswith("/home/user/asset-dashboard/.venv/bin/python")
+    assert parser.get("Service", "WorkingDirectory") == "/home/user/asset-dashboard"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 概要
PC起動/ログイン時にダッシュボードが自動起動するよう、OS別の登録手段を追加した (#59)。

## 変更内容
- **scripts/mf-tracker.service** (新規): systemd ユーザーサービスのテンプレート。`__WORKDIR__` / `__PYTHON__` を install.sh が絶対パスへ置換する。`Restart=on-failure`、`WantedBy=default.target`。
- **scripts/register-task.ps1** (新規): Windows のログオン時タスクを登録/解除。`pythonw.exe` でコンソール非表示起動。`-Unregister` で解除。
- **install.sh**: `--autostart` でユニットを生成し `systemctl --user enable --now` まで実行。systemctl 不在時は警告してスキップ。
- **install.ps1**: `-AutoStart` で register-task.ps1 を呼ぶ。
- **tests/test_systemd_unit.py** (新規): ユニットの構文・構造を検証。

起動コマンドは既存どおり `python -m src.web.server`（127.0.0.1:8080）。

## 自動テスト（pytest で検証済み）
- [x] systemd ユニットファイルの構文・必須セクション/キー検証 (`tests/test_systemd_unit.py` 6件パス)
- [x] プレースホルダ置換後に未解決トークンが残らない
- [x] `bash -n install.sh` 構文OK / `systemd-analyze verify` で構文エラーなし（実行ファイル不在の指摘のみ）

## 人間が確認すること
- [ ] Linux/WSL で `bash install.sh --autostart` 後、reboot（または `systemctl --user restart mf-tracker`）でサーバーが自動起動するか
- [ ] WSL など非ログインセッションでは `loginctl enable-linger $USER` が必要か確認
- [ ] Windows で `install.ps1 -AutoStart` 後、ログオンでコンソール非表示のまま起動するか
- [ ] サービス/タスクの停止・無効化（`systemctl --user disable --now mf-tracker` / `register-task.ps1 -Unregister`）が正常か

🤖 Generated with [Claude Code](https://claude.com/claude-code)